### PR TITLE
Skip go import in the same package

### DIFF
--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -292,7 +292,7 @@ func (fns goSharedFuncs) externalEnums(file pgs.File) []pgs.Enum {
 
 	for _, msg := range file.AllMessages() {
 		for _, fld := range msg.Fields() {
-			if en := fld.Type().Enum(); fld.Type().IsEnum() && en.Package().ProtoName() != fld.Package().ProtoName() {
+			if en := fld.Type().Enum(); fld.Type().IsEnum() && en.Package().ProtoName() != fld.Package().ProtoName() && fns.PackageName(en) != fns.PackageName(fld) {
 				out = append(out, en)
 			}
 		}


### PR DESCRIPTION
This patch resolves the bug of local import if ProtoName is different but Go package is the same case.

For example, the following proto definition causes problems.

foo.proto
```
syntax = "proto3";
package foo;
option go_package = "pb";

import "validate/validate.proto";

enum Role {
    ROLE_GUEST = 0;
    ROLE_VIEWER = 1;
    ROLE_ADMIN = 2;
}

message User {
    string id = 1;
    Role role = 2 [(validate.rules).enum.defined_only = true];
}
```

bar_service.proto
```
syntax = "proto3";
package bar_service;
option go_package = "pb";

import "validate/validate.proto";
import "foo.proto";

service bar {
    rpc GetUsersByRole(GetUsersByRoleRequest) returns (GetUsersByRoleResponse);
}

message GetUsersByRoleRequest {
    foo.Role role = 1 [(validate.rules).enum.defined_only = true];
}

message GetUsersByRoleResponse {
    repeated foo.User users = 1;
}
```

Generated `bar_service.pb.validate.go`
```
// Code generated by protoc-gen-validate. DO NOT EDIT.
// source: bar_service.proto

package pb

import (
	"bytes"
	"errors"
	"fmt"
	"net"
	"net/mail"
	"net/url"
	"regexp"
	"strings"
	"time"
	"unicode/utf8"

	"github.com/golang/protobuf/ptypes"

	pb "." // <- local import!!!!!!!!!!!
)

...
```

Use the generated definition will result in the following error.
```
bar_service.pb.validate.go:20:2: local import "." in non-local package
```


Please validate it.

Thanks.