### PR TITLE
Fix the circle ci build script to point to the settings file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ jobs:
               if [[ -n "${RELEASE}" && -n "${NEXT}" ]]; then
                 git config --global user.email "envoy-bot@users.noreply.github.com"
                 git config --global user.name "envoy-bot"
-                mvn -B -s .circleci/settings.xml release:prepare -Darguments="-s .circleci/settings.xml" -DreleaseVersion=$RELEASE -DdevelopmentVersion=$NEXT -DscmCommentPrefix="release: "
+                mvn -B -s ../.circleci/settings.xml release:prepare -Darguments="-s ../.circleci/settings.xml" -DreleaseVersion=$RELEASE -DdevelopmentVersion=$NEXT -DscmCommentPrefix="release: "
               else
-                mvn -B -s .circleci/settings.xml deploy
+                mvn -B -s ../.circleci/settings.xml deploy
               fi
             fi
 


### PR DESCRIPTION
I was watching the PR and saw that the build broke (https://circleci.com/gh/envoyproxy/protoc-gen-validate/95) thought I could donate the fix!

@rmichela 
@rodaine 

The working directory of the script is the java directory which is why the .circleci directory is not found in the current directory where the build is triggered