### PR TITLE
Update for bazel incompatible changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load('@bazel_tools//tools/build_defs/repo:http.bzl', 'http_archive')
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
-    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
+    sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
 )
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
When building envoy with bazel@HEAD to test for regressions, bazel CI
tests with upcoming incompatible changes. This PR fixes a few of those
experienced upstream:

`--incompatible_require_ctx_in_configure_features` & `--incompatible_enable_cc_toolchain_resolution`:

Updated rules_go to include upstream fixes for these.

`--incompatible_depset_is_not_iterable`:

Call `to_list` where needed

`--incompatible_disable_deprecated_attr_params`:

Change `single_file` to `allow_single_file`

`--incompatible_no_support_tools_in_action_inputs`:

Move `ctx.executable._plugin` to `tools` instead of `inputs`

`--incompatible_disable_legacy_proto_provider`:

Update proto API usage following https://github.com/bazelbuild/bazel/issues/7152