### PR TITLE
Embedded messages in protos with java_multiple_files=true throws NullPointerException

### DIFF
--- a/java/pgv-java-stub/pom.xml
+++ b/java/pgv-java-stub/pom.xml
@@ -91,6 +91,17 @@
                             <goal>test-compile</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>test-protoc-java-pgv</id>
+                        <goals>
+                            <goal>test-compile-custom</goal>
+                        </goals>
+                        <configuration>
+                            <pluginParameter>lang=java</pluginParameter>
+                            <pluginId>java-pgv</pluginId>
+                            <pluginArtifact>io.envoyproxy.protoc-gen-validate:protoc-gen-validate:${project.version}:exe:${os.detected.classifier}</pluginArtifact>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/java/pgv-java-stub/pom.xml
+++ b/java/pgv-java-stub/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>protobuf-java-util</artifactId>
             <version>${google.protobuf.version}</version>
         </dependency>
+        <!-- Depend on artifacts to ensure they are built before this module -->
+        <dependency>
+            <groupId>io.envoyproxy.protoc-gen-validate</groupId>
+            <artifactId>protoc-gen-validate</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/ReflectiveValidatorIndexTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/ReflectiveValidatorIndexTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ReflectiveValidatorIndexTest {
     @Test
     public void indexFindsOuterMessage() throws ValidationException {
-        TokenUse token = TokenUse.newBuilder().setPayload(TokenUse.Payload.newBuilder().setToken("FOO")).build();
+        TokenUse token = TokenUse.newBuilder().setPayload(TokenUse.Payload.newBuilder().setToken(TokenUse.Payload.Token.newBuilder().setValue("FOO"))).build();
         ReflectiveValidatorIndex index = new ReflectiveValidatorIndex();
         Validator<TokenUse> validator = index.validatorFor(TokenUse.class);
 
@@ -18,11 +18,21 @@ public class ReflectiveValidatorIndexTest {
 
     @Test
     public void indexFindsEmbeddedMessage() throws ValidationException {
-        TokenUse.Payload payload = TokenUse.Payload.newBuilder().setToken("FOO").build();
+        TokenUse.Payload payload = TokenUse.Payload.newBuilder().setToken(TokenUse.Payload.Token.newBuilder().setValue("FOO")).build();
         ReflectiveValidatorIndex index = new ReflectiveValidatorIndex();
         Validator<TokenUse.Payload> validator = index.validatorFor(TokenUse.Payload.class);
 
         assertThat(validator).withFailMessage("Unexpected Validator.ALWAYS_VALID").isNotEqualTo(Validator.ALWAYS_VALID);
         validator.assertValid(payload);
+    }
+
+    @Test
+    public void indexFindsDoubleEmbeddedMessage() throws ValidationException {
+        TokenUse.Payload.Token token = TokenUse.Payload.Token.newBuilder().setValue("FOO").build();
+        ReflectiveValidatorIndex index = new ReflectiveValidatorIndex();
+        Validator<TokenUse.Payload.Token> validator = index.validatorFor(TokenUse.Payload.Token.class);
+
+        assertThat(validator).withFailMessage("Unexpected Validator.ALWAYS_VALID").isNotEqualTo(Validator.ALWAYS_VALID);
+        validator.assertValid(token);
     }
 }

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/ReflectiveValidatorIndexTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/ReflectiveValidatorIndexTest.java
@@ -1,0 +1,28 @@
+package io.envoyproxy.pgv;
+
+import io.envoyproxy.pvg.cases.TokenUse;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReflectiveValidatorIndexTest {
+    @Test
+    public void indexFindsOuterMessage() throws ValidationException {
+        TokenUse token = TokenUse.newBuilder().setPayload(TokenUse.Payload.newBuilder().setToken("FOO")).build();
+        ReflectiveValidatorIndex index = new ReflectiveValidatorIndex();
+        Validator<TokenUse> validator = index.validatorFor(TokenUse.class);
+
+        assertThat(validator).withFailMessage("Unexpected Validator.ALWAYS_VALID").isNotEqualTo(Validator.ALWAYS_VALID);
+        validator.assertValid(token);
+    }
+
+    @Test
+    public void indexFindsEmbeddedMessage() throws ValidationException {
+        TokenUse.Payload payload = TokenUse.Payload.newBuilder().setToken("FOO").build();
+        ReflectiveValidatorIndex index = new ReflectiveValidatorIndex();
+        Validator<TokenUse.Payload> validator = index.validatorFor(TokenUse.Payload.class);
+
+        assertThat(validator).withFailMessage("Unexpected Validator.ALWAYS_VALID").isNotEqualTo(Validator.ALWAYS_VALID);
+        validator.assertValid(payload);
+    }
+}

--- a/java/pgv-java-stub/src/test/proto/embedded.proto
+++ b/java/pgv-java-stub/src/test/proto/embedded.proto
@@ -8,7 +8,10 @@ import "validate/validate.proto";
 
 message TokenUse {
     message Payload {
-        string token = 1;
+        message Token {
+            string value = 1;
+        }
+        Token token = 1;
     }
     Payload payload = 1;
 }

--- a/java/pgv-java-stub/src/test/proto/embedded.proto
+++ b/java/pgv-java-stub/src/test/proto/embedded.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package io.envoyproxy.pvg.cases;
+
+option java_multiple_files = true;
+
+import "validate/validate.proto";
+
+message TokenUse {
+    message Payload {
+        string token = 1;
+    }
+    Payload payload = 1;
+}

--- a/templates/java/file.go
+++ b/templates/java/file.go
@@ -24,9 +24,15 @@ public class {{ classNameFile . }}Validator {
 public class {{ classNameMessage .}}Validator implements io.envoyproxy.pgv.ValidatorImpl<{{ qualifiedName . }}>{
 	public static io.envoyproxy.pgv.ValidatorImpl validatorFor(Class clazz) {
 		if (clazz.equals({{ qualifiedName . }}.class)) return new {{ simpleName .}}Validator();
+		{{ range .AllMessages }}
+		if (clazz.equals({{ qualifiedName . }}.class)) return new {{ simpleName .}}Validator();
+		{{- end }}
 		return null;
 	}
 	{{- template "msgInner" . -}}
+	{{ range .AllMessages -}}
+	{{- template "msg" . -}}
+	{{- end }}
 }
 {{ end }}
 `


### PR DESCRIPTION
Fixes #208

It appears validators for nested message types aren't being properly generated when `java_multiple_files=true`.