### PR TITLE
Add Java ValidationExceptions helper

### DIFF
--- a/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidatingClientInterceptor.java
+++ b/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidatingClientInterceptor.java
@@ -24,8 +24,7 @@ public class ValidatingClientInterceptor implements ClientInterceptor {
                     index.validatorFor(message.getClass()).assertValid(message);
                     super.sendMessage(message);
                 } catch (ValidationException ex) {
-                    Status status = Status.INVALID_ARGUMENT.withDescription(ex.getMessage());
-                    throw new StatusRuntimeException(status);
+                    throw ValidationExceptions.asStatus(ex).asRuntimeException();
                 }
             }
         };

--- a/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidatingServerInterceptor.java
+++ b/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidatingServerInterceptor.java
@@ -29,7 +29,7 @@ public class ValidatingServerInterceptor implements ServerInterceptor {
                     index.validatorFor(message.getClass()).assertValid(message);
                     super.onMessage(message);
                 } catch (ValidationException ex) {
-                    Status status = Status.INVALID_ARGUMENT.withDescription(ex.getMessage());
+                    Status status = ValidationExceptions.asStatus(ex);
                     aborted = true;
                     call.close(status, new Metadata());
                 }

--- a/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidationExceptions.java
+++ b/java/pgv-java-grpc/src/main/java/io/envoyproxy/pgv/grpc/ValidationExceptions.java
@@ -1,0 +1,22 @@
+package io.envoyproxy.pgv.grpc;
+
+import io.envoyproxy.pgv.ValidationException;
+import io.grpc.Status;
+
+/**
+ * {@code ValidationExceptions} provides utilities for converting {@link ValidationException} objects into gRPC
+ * {@code Status} objects.
+ */
+public final class ValidationExceptions {
+    private ValidationExceptions() { }
+
+    /**
+     * Convert a {@link ValidationException} into a gRPC {@code Status.INVALID_ARGUMENT} with appropriate message
+     * and cause.
+     * @param ex the {@code ValidationException} to convert.
+     * @return a gRPC {@code Status.INVALID_ARGUMENT}
+     */
+    public static Status asStatus(ValidationException ex) {
+        return Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).withCause(ex);
+    }
+}


### PR DESCRIPTION
Added a small helper class to standardize the conversion of a `ValidationException` to gRPC's `Status.INVALID_ARGUMENT`.