### PR TITLE
Changed Java email validation

### DIFF
--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -20,6 +20,9 @@ public final class StringValidation {
         // Intentionally left blank.
     }
 
+    // Defers initialization until needed and from there on we keep an object
+    // reference and avoid future calls; it is safe to assume that we require
+    // the instance again after initialization.
     private static class Lazy {
         static final EmailValidator EMAIL_VALIDATOR = EmailValidator.getInstance(true, true);
     }

--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -89,17 +89,14 @@ public final class StringValidation {
             final char[] chars = value.toCharArray();
             final StringBuilder sb = new StringBuilder();
             boolean insideQuotes = false;
-            loop: for (int i = chars.length - 2; i >= 0; i--) {
-                switch (chars[i]) {
-                    case '<':
-                        if (!insideQuotes) break loop;
-
-                    case '"':
-                        insideQuotes = !insideQuotes;
-
-                    default:
-                        sb.append(chars[i]);
+            for (int i = chars.length - 2; i >= 0; i--) {
+                final char c = chars[i];
+                if (c == '<') {
+                    if (!insideQuotes) break;
+                } else if (c == '"') {
+                    insideQuotes = !insideQuotes;
                 }
+                sb.append(c);
             }
             value = sb.reverse().toString();
         }

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
@@ -131,8 +131,11 @@ public class StringValidationTest {
         // Match
         StringValidation.email("x", "foo@bar.com");
         StringValidation.email("x", "John Smith <foo@bar.com>");
+        StringValidation.email("x", "John Doe <john.\"we<i<>r>do\".doe@example.com>");
         // No Match
         assertThatThrownBy(() -> StringValidation.email("x", "bar.bar.bar")).isInstanceOf(ValidationException.class);
+        assertThatThrownBy(() -> StringValidation.email("x", "John Doe <john.doe@example.com")).isInstanceOf(ValidationException.class);
+        assertThatThrownBy(() -> StringValidation.email("x", "John Doe <john.doe@example.com> ")).isInstanceOf(ValidationException.class);
     }
 
     @Test


### PR DESCRIPTION
* Added support for quoted email addresses (as per RFC).
* Added guardian around display email address extraction to execute the logic only if we are certain that it is in display format.
* Changed logic to extract email address from display form. Replaced the regular expression with a simpler loop based algorithm.
* Changed the email validator instance retrieval. Placed it in a lazy holder class which means that we get the instance when it is first required and keep a reference on the object for the lifetime of the program so that subsequent retrievals are faster (which are likely since it was required). No additional object is allocated because we only keep a reference on the already existing instance.