### PR TITLE
Changed Java details

### DIFF
--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/ReflectiveValidatorIndex.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/ReflectiveValidatorIndex.java
@@ -11,7 +11,7 @@ public final class ReflectiveValidatorIndex implements ValidatorIndex {
     private final ConcurrentHashMap<Class, Validator> VALIDATOR_INDEX = new ConcurrentHashMap<>();
 
     /**
-     * Retuns the validator for {@code <T>}, or {@code ALWAYS_VALID} if not found.
+     * Returns the validator for {@code <T>}, or {@code ALWAYS_VALID} if not found.
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -166,6 +166,11 @@ public final class StringValidation {
     }
 
     private static boolean isAscii(final String value) {
-        return value.chars().allMatch(it -> it >= 0 && it <= 127);
+        for (char c : value.toCharArray()) {
+            if (c > 127) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -1,6 +1,5 @@
 package io.envoyproxy.pgv;
 
-import com.google.common.base.CharMatcher;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import org.apache.commons.validator.routines.DomainValidator;
@@ -9,11 +8,12 @@ import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * {@code StringValidation} implements PGV validation for protobuf {@code String} fields.
  */
+@SuppressWarnings("WeakerAccess")
 public final class StringValidation {
     private StringValidation() {
     }
@@ -37,19 +37,19 @@ public final class StringValidation {
     }
 
     public static void lenBytes(String field, String value, int expected) throws ValidationException {
-        if (value.getBytes(Charset.forName("UTF-8")).length != expected) {
+        if (value.getBytes(StandardCharsets.UTF_8).length != expected) {
             throw new ValidationException(field, enquote(value), "bytes length must be " + expected);
         }
     }
 
     public static void minBytes(String field, String value, int expected) throws ValidationException {
-        if (value.getBytes(Charset.forName("UTF-8")).length < expected) {
+        if (value.getBytes(StandardCharsets.UTF_8).length < expected) {
             throw new ValidationException(field, enquote(value), "bytes length must be at least " + expected);
         }
     }
 
     public static void maxBytes(String field, String value, int expected) throws ValidationException {
-        if (value.getBytes(Charset.forName("UTF-8")).length > expected) {
+        if (value.getBytes(StandardCharsets.UTF_8).length > expected) {
             throw new ValidationException(field, enquote(value), "bytes length must be at maximum " + expected);
         }
     }
@@ -94,7 +94,7 @@ public final class StringValidation {
     }
 
     public static void address(String field, String value) throws ValidationException {
-        boolean validHost = CharMatcher.ascii().matchesAllOf(value) && DomainValidator.getInstance(true).isValid(value);
+        boolean validHost = isAscii(value) && DomainValidator.getInstance(true).isValid(value);
         boolean validIp = InetAddressValidator.getInstance().isValid(value);
 
         if (!validHost && !validIp) {
@@ -103,7 +103,7 @@ public final class StringValidation {
     }
 
     public static void hostName(String field, String value) throws ValidationException {
-        if (!CharMatcher.ascii().matchesAllOf(value)) {
+        if (!isAscii(value)) {
             throw new ValidationException(field, enquote(value), "should be a valid host containing only ascii characters");
         }
 
@@ -147,7 +147,7 @@ public final class StringValidation {
 
     public static void uriRef(String field, String value) throws ValidationException {
         try {
-            URI uri = new URI(value);
+            new URI(value);
         } catch (URISyntaxException ex) {
             throw new ValidationException(field, enquote(value), "should be a valid absolute uri");
         }
@@ -163,5 +163,9 @@ public final class StringValidation {
 
     private static String enquote(String value) {
         return "\"" + value + "\"";
+    }
+
+    private static boolean isAscii(final String value) {
+        return value.chars().allMatch(it -> it >= 0 && it <= 127);
     }
 }


### PR DESCRIPTION
* Changed `Charset.forName("UTF-8")` to `StandardCharsets.UTF_8` to avoid string construction and typos.
* Removed Google `CharMatcher` dependency by adding a faster pure Java utility function to validate if a string consists solely of ASCII characters or not. However, the new function like the previous one still allows for control characters.