### PR TITLE
Changed Java UUID from Regex to FSM

### DIFF
--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -1,6 +1,5 @@
 package io.envoyproxy.pgv;
 
-import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.commons.validator.routines.EmailValidator;

--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -15,6 +15,11 @@ import java.nio.charset.StandardCharsets;
  */
 @SuppressWarnings("WeakerAccess")
 public final class StringValidation {
+    private static final int UUID_DASH_1 = 8;
+    private static final int UUID_DASH_2 = 13;
+    private static final int UUID_DASH_3 = 18;
+    private static final int UUID_DASH_4 = 23;
+
     private StringValidation() {
         // Intentionally left blank.
     }
@@ -171,6 +176,11 @@ public final class StringValidation {
         }
     }
 
+    /**
+     * Validates if the given value is a UUID or GUID in short
+     * ({@code 00000000000000000000000000000000}) or hyphenated
+     * ({@code 00000000-0000-0000-0000-000000000000}) form.
+     */
     public static void uuid(final String field, final String value) throws ValidationException {
         final char[] chars = value.toCharArray();
 
@@ -185,7 +195,11 @@ public final class StringValidation {
 
             case 36:
                 for (int i = 0; i < chars.length; i++) {
-                    if (isNotHexDigit(chars[i]) && ((i == 8 || i == 13 || i == 18 || i == 23) && chars[i] != '-')) {
+                    if (i == UUID_DASH_1 || i == UUID_DASH_2 || i == UUID_DASH_3 || i == UUID_DASH_4) {
+                        if (chars[i] != '-') {
+                            break err;
+                        }
+                    } else if (isNotHexDigit(chars[i])) {
                         break err;
                     }
                 }

--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -171,12 +171,32 @@ public final class StringValidation {
         }
     }
 
-    private static final Pattern uuidPattern = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
-    public static void uuid(String field, String value) throws ValidationException {
-        Matcher matcher = uuidPattern.matcher(value);
-        if (!matcher.matches()) {
-            throw new ValidationException(field, enquote(value), "should be a valid uuid");
+    public static void uuid(final String field, final String value) throws ValidationException {
+        final char[] chars = value.toCharArray();
+
+        err: switch (chars.length) {
+            case 32:
+                for (final char c : chars) {
+                    if (isNotHexDigit(c)) {
+                        break err;
+                    }
+                }
+                return;
+
+            case 36:
+                for (int i = 0; i < chars.length; i++) {
+                    if (isNotHexDigit(chars[i]) && ((i == 8 || i == 13 || i == 18 || i == 23) && chars[i] != '-')) {
+                        break err;
+                    }
+                }
+                return;
         }
+
+        throw new ValidationException(field, enquote(value), "invalid UUID string");
+    }
+
+    private static boolean isNotHexDigit(final char c) {
+        return (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F');
     }
 
     private static String enquote(String value) {

--- a/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
+++ b/java/pgv-java-stub/src/main/java/io/envoyproxy/pgv/StringValidation.java
@@ -18,6 +18,7 @@ public final class StringValidation {
     private static final int UUID_DASH_2 = 13;
     private static final int UUID_DASH_3 = 18;
     private static final int UUID_DASH_4 = 23;
+    private static final int UUID_LEN = 36;
 
     private StringValidation() {
         // Intentionally left blank.
@@ -176,40 +177,28 @@ public final class StringValidation {
     }
 
     /**
-     * Validates if the given value is a UUID or GUID in short
-     * ({@code 00000000000000000000000000000000}) or hyphenated
-     * ({@code 00000000-0000-0000-0000-000000000000}) form.
+     * Validates if the given value is a UUID or GUID in RFC 4122 hyphenated
+     * ({@code 00000000-0000-0000-0000-000000000000}) form; both lower and upper
+     * hex digits are accepted.
      */
     public static void uuid(final String field, final String value) throws ValidationException {
         final char[] chars = value.toCharArray();
 
-        err: switch (chars.length) {
-            case 32:
-                for (final char c : chars) {
-                    if (isNotHexDigit(c)) {
+        err: if (chars.length == UUID_LEN) {
+            for (int i = 0; i < chars.length; i++) {
+                final char c = chars[i];
+                if (i == UUID_DASH_1 || i == UUID_DASH_2 || i == UUID_DASH_3 || i == UUID_DASH_4) {
+                    if (c != '-') {
                         break err;
                     }
+                } else if ((c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F')) {
+                    break err;
                 }
-                return;
-
-            case 36:
-                for (int i = 0; i < chars.length; i++) {
-                    if (i == UUID_DASH_1 || i == UUID_DASH_2 || i == UUID_DASH_3 || i == UUID_DASH_4) {
-                        if (chars[i] != '-') {
-                            break err;
-                        }
-                    } else if (isNotHexDigit(chars[i])) {
-                        break err;
-                    }
-                }
-                return;
+            }
+            return;
         }
 
         throw new ValidationException(field, enquote(value), "invalid UUID string");
-    }
-
-    private static boolean isNotHexDigit(final char c) {
-        return (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F');
     }
 
     private static String enquote(String value) {

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/Assertions.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/Assertions.java
@@ -1,0 +1,15 @@
+package io.envoyproxy.pgv;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public final class Assertions {
+    private Assertions() {
+        // Intentionally left blank.
+    }
+
+    public static void assertValidationException(final ThrowingCallable f) {
+        assertThatThrownBy(f).isInstanceOf(ValidationException.class);
+    }
+}

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
@@ -221,6 +221,8 @@ public class StringValidationTest {
 
     @Test
     public void uuidWorks() throws ValidationException {
+        // We use this to generate UUIDs in short and hyphenated form for all
+        // valid hex digits, so 00000000-0000…, 11111111-1111…, …
         char[] chars = "0123456789abcdefABCDEF".toCharArray();
 
         // Match

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
@@ -221,35 +221,28 @@ public class StringValidationTest {
 
     @Test
     public void uuidWorks() throws ValidationException {
-        // We use this to generate UUIDs in short and hyphenated form for all
-        // valid hex digits, so 00000000-0000…, 11111111-1111…, …
+        // We use this to generate UUIDs for all valid hex digits, so:
+        // 00000000-0000…, 11111111-1111…, …, FFFFFFFF-FFFF…
         char[] chars = "0123456789abcdefABCDEF".toCharArray();
 
         // Match
         for (char c : chars) {
-            uuid("simple_" + c, repeat(c, 32));
-        }
-        for (char c : chars) {
             final String s4 = repeat(c, 4);
-            uuid("hyphenated_" + c, repeat(c, 8) + '-' + s4 + '-' + s4 + '-' + s4 + '-' + repeat(c, 12));
+            uuid(String.valueOf(c), repeat(c, 8) + '-' + s4 + '-' + s4 + '-' + s4 + '-' + repeat(c, 12));
         }
 
         // No Match
-        assertValidationException(() -> uuid("simple_g", "0000000000000000000000000000000g"));
-        assertValidationException(() -> uuid("simple_short", "0000000000000000000000000000000"));
-        assertValidationException(() -> uuid("simple_long", "000000000000000000000000000000000"));
-
-        assertValidationException(() -> uuid("hyphenated_g", "00000000-0000-0000-0000-00000000000g"));
-        assertValidationException(() -> uuid("hyphenated_underscore", "00000000-0000_0000-0000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_short", "00000000-000000000-0000-00000000000"));
-        assertValidationException(() -> uuid("hyphenated_long", "00000000-000000000-0000-0000000000000"));
-        assertValidationException(() -> uuid("hyphenated_1_dash_at_07", "0000000-00000-0000-0000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_1_dash_at_09", "000000000-000-0000-0000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_2_dash_at_12", "00000000-000-00000-0000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_2_dash_at_14", "00000000-00000-000-0000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_3_dash_at_17", "00000000-0000-000-00000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_3_dash_at_19", "00000000-0000-00000-000-000000000000"));
-        assertValidationException(() -> uuid("hyphenated_4_dash_at_22", "00000000-0000-0000-000-0000000000000"));
-        assertValidationException(() -> uuid("hyphenated_4_dash_at_24", "00000000-0000-0000-00000-00000000000"));
+        assertValidationException(() -> uuid("g", "00000000-0000-0000-0000-00000000000g"));
+        assertValidationException(() -> uuid("underscore", "00000000-0000_0000-0000-000000000000"));
+        assertValidationException(() -> uuid("short", "00000000-000000000-0000-00000000000"));
+        assertValidationException(() -> uuid("long", "00000000-000000000-0000-0000000000000"));
+        assertValidationException(() -> uuid("1_dash_at_07", "0000000-00000-0000-0000-000000000000"));
+        assertValidationException(() -> uuid("1_dash_at_09", "000000000-000-0000-0000-000000000000"));
+        assertValidationException(() -> uuid("2_dash_at_12", "00000000-000-00000-0000-000000000000"));
+        assertValidationException(() -> uuid("2_dash_at_14", "00000000-00000-000-0000-000000000000"));
+        assertValidationException(() -> uuid("3_dash_at_17", "00000000-0000-000-00000-000000000000"));
+        assertValidationException(() -> uuid("3_dash_at_19", "00000000-0000-00000-000-000000000000"));
+        assertValidationException(() -> uuid("4_dash_at_22", "00000000-0000-0000-000-0000000000000"));
+        assertValidationException(() -> uuid("4_dash_at_24", "00000000-0000-0000-00000-00000000000"));
     }
 }


### PR DESCRIPTION
* Changed Java UUID validation from a regular expression to a hardcoded finite state machine. This should provide a significant speed-up.
* Added UUID simple format support to Java UUID validation (the simple format is without dashes).