### PR TITLE
regression test for multiple_java_files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ bazel:
 	# generate the PGV plugin with Bazel
 	bazel build //tests/...
 
+.PHONY: build_generation_tests
+build_generation_tests:
+	bazel build //tests/generation/...
+
 .PHONY: gazelle
 gazelle: vendor
 	# runs gazelle against the codebase to generate Bazel BUILD files
@@ -134,7 +138,7 @@ tests/harness/java/java-harness:
 	mvn -q -f java/pom.xml clean package -DskipTests
 
 .PHONY: ci
-ci: lint build testcases bazel-harness
+ci: lint bazel testcases bazel-harness build_generation_tests
 
 .PHONY: clean
 clean:

--- a/tests/generation/multi_file_java_test/BUILD
+++ b/tests/generation/multi_file_java_test/BUILD
@@ -1,0 +1,29 @@
+load(
+    "//bazel:pgv_proto_library.bzl",
+    "pgv_cc_proto_library",
+)
+
+proto_library(
+    name = "test_proto",
+    srcs = ["test.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+    ],
+)
+
+pgv_cc_proto_library(
+  name = "test_cc_proto",
+  deps = [":test_proto"],
+  visibility = ["//visibility:public"],
+)
+
+
+cc_binary(
+    name = "cc-mfjt-test",
+    srcs = ["main.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":test_cc_proto",
+    ],
+)

--- a/tests/generation/multi_file_java_test/README.md
+++ b/tests/generation/multi_file_java_test/README.md
@@ -1,0 +1,5 @@
+# Multi File Java Test #
+
+Test that a file with: `option java_multiple_files = true;` not generated in
+java can properly be generated without error. Due to `java` not needing to be
+in the generation path at all we had to split it out into it's own directory.

--- a/tests/generation/multi_file_java_test/main.cc
+++ b/tests/generation/multi_file_java_test/main.cc
@@ -1,0 +1,8 @@
+#include <iostream>
+
+#include "tests/generation/multi_file_java_test/test.pb.h"
+#include "tests/generation/multi_file_java_test/test.pb.validate.h"
+
+int main(int argc, char** argv) {
+  return 0;
+}

--- a/tests/generation/multi_file_java_test/test.proto
+++ b/tests/generation/multi_file_java_test/test.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package tests.mfjt;
+option go_package = "harness";
+option java_multiple_files = true;
+
+import "google/protobuf/any.proto";
+
+message Message {
+    google.protobuf.Any data = 1;
+}


### PR DESCRIPTION
this adds in a regression test for the multiple_java_files option
trying to generate java files even when java wasn't an output.
this test breaks before the fix, but works on master since the
fix is in play.