### PR TITLE
Convert File Name to Snake Case for UUID Pattern matching variables

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -44,7 +44,7 @@ var (
 )
 
 // define the regex for a UUID once up-front
-var _{{ .File.InputPath.BaseName }}_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+var _{{ snakeCase .File.InputPath.BaseName }}_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 {{ range .AllMessages }}
 	{{ template "msg" . }}

--- a/templates/gogo/file.go
+++ b/templates/gogo/file.go
@@ -44,7 +44,7 @@ var (
 )
 
 // define the regex for a UUID once up-front
-var _{{ .File.InputPath.BaseName }}_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+var _{{ snakeCase .File.InputPath.BaseName }}_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 {{ range .AllMessages }}
 	{{ template "msg" . }}

--- a/templates/goshared/BUILD.bazel
+++ b/templates/goshared/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//templates/shared:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star/lang/go:go_default_library",
+        "//vendor/github.com/iancoleman/strcase:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",

--- a/templates/goshared/known.go
+++ b/templates/goshared/known.go
@@ -56,7 +56,7 @@ const emailTpl = `
 
 const uuidTpl = `
 	func (m {{ (msgTyp .).Pointer }}) _validateUuid(uuid string) error {
-		if matched := _{{ .File.InputPath.BaseName }}_uuidPattern.MatchString(uuid); !matched {
+		if matched := _{{ snakeCase .File.InputPath.BaseName }}_uuidPattern.MatchString(uuid); !matched {
 			return errors.New("invalid uuid format")
 		}
 

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -2,6 +2,7 @@ package goshared
 
 import (
 	"fmt"
+	"github.com/iancoleman/strcase"
 	"reflect"
 	"strings"
 	"text/template"
@@ -20,6 +21,7 @@ func Register(tpl *template.Template, params pgs.Parameters) {
 	tpl.Funcs(map[string]interface{}{
 		"accessor":      fns.accessor,
 		"byteStr":       fns.byteStr,
+		"snakeCase":	 fns.snakeCase,
 		"cmt":           pgs.C80,
 		"durGt":         fns.durGt,
 		"durLit":        fns.durLit,
@@ -310,4 +312,8 @@ func (fns goSharedFuncs) enumPackages(enums []pgs.Enum) map[pgs.FilePath]pgs.Nam
 	}
 
 	return out
+}
+
+func (fns goSharedFuncs) snakeCase(name string) string {
+	return strcase.ToSnake(name)
 }


### PR DESCRIPTION
If a proto file has a name like `str-ing.proto`, the post processor would complain as Golang variables cannot have hyphens in their name. 

This change just converts the file name to snake case to avoid this problem.