### PR TITLE
undef conflicting macros on windows

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -14,6 +14,15 @@
 #else
 #include <winsock2.h>
 #include <ws2tcpip.h>
+
+// <windows.h> uses macros to #define a ton of symbols, two of which (DELETE and GetMessage)
+// interfere with our code. DELETE shows up in the base.pb.h header generated from
+// api/envoy/api/core/base.proto. Since it's a generated header, we can't #undef DELETE at
+// the top of that header to avoid the collision. Similarly, GetMessage shows up in generated
+// protobuf code so we can't #undef the symbol there.
+#undef DELETE
+#undef GetMessage
+
 #endif
 
 namespace pgv {


### PR DESCRIPTION
<windows.h> uses macros to #define a ton of symbols, two of which (DELETE and GetMessage)
interfere with our code. DELETE shows up in the base.pb.h header generated from
api/envoy/api/core/base.proto. Since it's a generated header, we can't #undef DELETE at
the top of that header to avoid the collision. Similarly, GetMessage shows up in generated
protobuf code so we can't #undef the symbol there.

Signed-off-by: @wrowe 