### PR TITLE
Add missing go_package for gogoproto

### DIFF
--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -33,6 +33,7 @@ import "google/protobuf/descriptor.proto";
 
 option java_package = "com.google.protobuf";
 option java_outer_classname = "GoGoProtos";
+option go_package = "github.com/gogo/protobuf/gogoproto";
 
 extend google.protobuf.EnumOptions {
 	optional bool goproto_enum_prefix = 62001;


### PR DESCRIPTION
The copy of [gogoproto](https://github.com/gogo/protobuf) is missing option `go_package`. This will cause generated code got wrong import path in Golang.

```go
import (
	_ "gogoproto"
)
```

And the Go compiler will complain about cannot find the `gogoproto` package.

After fixing, the import path will look like this
```go
import (
	_ "github.com/gogo/protobuf/gogoproto"
)
```
Then we're good to go.