### PR TITLE
implement utf-8 length for c++ validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ bazel-*
 /tests/harness/cc/cc-harness
 /tests/harness/cc/cc-harness.exe
 
+/validate/__pycache__
+
 /tests/harness/cases/**/*.cc
 /tests/harness/cases/**/*.h
 

--- a/rule_comparison.md
+++ b/rule_comparison.md
@@ -1,18 +1,18 @@
 # Constraint Rule Comparison
 ## Global
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | disabled               |✅|✅|✅|✅|✅|
 
 ## Numerics
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | const                  |✅|✅|✅|✅|✅|
 | lt/lte/gt/gte          |✅|✅|✅|✅|✅|
 | in/not_in              |✅|✅|✅|✅|✅|
 
 ## Bools
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | const                  |✅|✅|✅|✅|✅|
 
@@ -20,7 +20,7 @@
 | Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | const                  |✅|✅|✅|✅|✅|
-| len/min\_len/max_len   |✅|✅|❌|✅|✅|
+| len/min\_len/max_len   |✅|✅|✅|✅|✅|
 | min\_bytes/max\_bytes  |✅|✅|✅|✅|✅|
 | pattern                |✅|✅|❌|✅|✅|
 | prefix/suffix/contains |✅|✅|✅|✅|✅|
@@ -48,51 +48,51 @@
 | ipv6                   |✅|✅|❌|✅|✅|
 
 ## Enums
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | const                  |✅|✅|✅|✅|✅|
 | defined_only           |✅|✅|✅|✅|✅|
 | in/not_in              |✅|✅|✅|✅|✅|
 
 ## Messages
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | skip                   |✅|✅|✅|✅|✅|
 | required               |✅|✅|✅|✅|✅|
 
 ## Repeated
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | min\_items/max_items   |✅|✅|✅|✅|✅|
 | unique                 |✅|✅|✅|✅|✅|
 | items                  |✅|✅|❌|✅|✅|
 
 ## Maps
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
-| min\_pairs/max_pairs   |✅|✅|❌|✅|✅|
+| min\_pairs/max_pairs   |✅|✅|✅|✅|✅|
 | no_sparse              |✅|✅|❌|❌|❌|
 | keys                   |✅|✅|❌|✅|✅|
 | values                 |✅|✅|❌|✅|✅|
 
 ## OneOf
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | required               |✅|✅|✅|✅|✅|
 
 ## WKT Scalar Value Wrappers
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | wrapper validation     |✅|✅|✅|✅|✅|
 
 ## WKT Any
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | required               |✅|✅|✅|✅|✅|
 | in/not_in              |✅|✅|✅|✅|✅|
 
 ## WKT Duration
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | required               |✅|✅|✅|✅|✅|
 | const                  |✅|✅|✅|✅|✅|
@@ -100,7 +100,7 @@
 | in/not_in              |✅|✅|✅|✅|✅|
 
 ## WKT Timestamp
-| Constraint Rule | Go | GoGo | C++ | Java | Python | 
+| Constraint Rule | Go | GoGo | C++ | Java | Python |
 | ---| :---: | :---: | :---: | :---: | :---: |
 | required               |✅|✅|❌|✅|✅|
 | const                  |✅|✅|❌|✅|✅|

--- a/templates/cc/msg.go
+++ b/templates/cc/msg.go
@@ -83,13 +83,4 @@ bool Validate(const {{ class . }}& m, pgv::ValidationMsg* err) {
 	return true;
 {{ end -}}
 }
-
-{{/* TODO(akonradi) implement hostname matching
-{{ if needs . "hostname" }}{{ template "hostname" . }}{{ end }}
-
-{{ if needs . "email" }}{{ template "email" . }}{{ end }}
-
-{{ if needs . "uuid" }}{{ template "uuid" . }}{{ end }}
-*/}}
-
 `

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -241,7 +241,7 @@ func (fns CCFuncs) lit(x interface{}) string {
 	case reflect.String:
 		return fmt.Sprintf("%q", x)
 	case reflect.Uint8:
-		return fmt.Sprintf("0x%X", x)
+		return fmt.Sprintf("%d", x)
 	case reflect.Slice:
 		els := make([]string, val.Len())
 		switch reflect.TypeOf(x).Elem().Kind() {

--- a/templates/cc/string.go
+++ b/templates/cc/string.go
@@ -5,40 +5,32 @@ const strTpl = `
 	{{ template "const" . }}
 	{{ template "in" . }}
 	{{ if or $r.Len (and $r.MinLen $r.MaxLen (eq $r.GetMinLen $r.GetMaxLen)) }}
-		{{ unimplemented }}
 		{{ if $r.Len }}
-			{{/* TODO(akonradi) implement UTF-8 length constraints
-			if utf8.RuneCountInString({{ accessor . }}) != {{ $r.GetLen }} {
-				return {{ err . "value length must be " $r.GetLen " runes" }}
+			if (pgv::Utf8Len({{ accessor . }}) != {{ $r.GetLen }}) {
+				{{ err . "value must be " $r.GetLen " runes" }}
 			}
-			*/}}
 		{{ else }}
-			{{/* TODO(akonradi) implement UTF-8 length constraints
-			if utf8.RuneCountInString({{ accessor . }}) != {{ $r.GetMinLen }} {
-				return {{ err . "value length must be " $r.GetMinLen " runes" }}
+			if (pgv::Utf8Len({{ accessor . }}) != {{ $r.GetMinLen }}) {
+				{{ err . "value must be " $r.GetMinLen " runes" }}
 			}
-			*/}}
 		{{ end }}
 	{{ else if $r.MinLen }}
-		{{ unimplemented }}
-		{{/* TODO(akonradi) implement UTF-8 length constraints
 		{{ if $r.MaxLen }}
-			if l := utf8.RuneCountInString({{ accessor . }}); l < {{ $r.GetMinLen }} || l > {{ $r.GetMaxLen }} {
-				return {{ err . "value length must be between " $r.GetMinLen " and " $r.GetMaxLen " runes, inclusive" }}
+			{
+				const auto length = pgv::Utf8Len({{ accessor . }});
+				if (length < {{ $r.GetMinLen }} || length > {{ $r.GetMaxLen }}) {
+					{{ err . "value must have between " $r.GetMinLen " and " $r.GetMaxLen " runes inclusive" }}
+				}
 			}
 		{{ else }}
-			if utf8.RuneCountInString({{ accessor . }}) < {{ $r.GetMinLen }} {
-				return {{ err . "value length must be at least " $r.GetMinLen " runes" }}
+			if (pgv::Utf8Len({{ accessor . }}) < {{ $r.GetMinLen }}) {
+				{{ err . "value length must be at least " $r.GetMinLen " runes" }}
 			}
 		{{ end }}
-		*/}}
 	{{ else if $r.MaxLen }}
-		{{ unimplemented }}
-		{{/* TODO(akonradi) implement UTF-8 length constraints
-		if utf8.RuneCountInString({{ accessor . }}) > {{ $r.GetMaxLen }} {
-			return {{ err . "value length must be at most " $r.GetMaxLen " runes" }}
+		if (pgv::Utf8Len({{ accessor . }}) > {{ $r.GetMaxLen }}) {
+			{{ err . "value length must be at most " $r.GetMaxLen " runes" }}
 		}
-		*/}}
 	{{ end }}
 
 	{{ if or $r.LenBytes (and $r.MinBytes $r.MaxBytes (eq $r.GetMinBytes $r.GetMaxBytes)) }}

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -1,6 +1,7 @@
 #ifndef _VALIDATE_H
 #define _VALIDATE_H
 
+#include <codecvt>
 #include <functional>
 #include <regex>
 #include <stdexcept>
@@ -127,6 +128,11 @@ static inline bool IsHostname(const string& to_validate) {
   }
 
   return true;
+}
+
+static inline size_t Utf8Len(const string& narrow_string) {
+  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
+  return converter.from_bytes(narrow_string).size();
 }
 
 } // namespace pgv


### PR DESCRIPTION
this commit implements utf-8 length string checking in C++ for
validations, and updates the readme table.

---

there's also a small update to the gitignore, to ignore a __pycache__
dir that was created for me when running make ci locally inside of
docker.

---

Note this does use a deprecated (in c++17) feature: `codecvt`. This was a tough choice but I thoroughly believe it's the best choice for this particular feature:

- According to the deprecation proposal it cannot be removed, until a replacement exists: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0618r0.html in which case we could switch to that when it comes out.

- Bringing in a library for a singular length function seems incredibly wasteful. Maybe if we were doing more utf-8 specific validation? However using one small part of a conversion library, for one tiny function that bloats binary size doesn't seem like the right tradeoff.

- There are mentions of: "security issues" about converter not properly handling utf codepoints. I've been able to find little data about this, but thinking about it the worst that would happen is we'd return the incorrect utf-8 length. Which wouldn't be used for any buffers/anything of importance from a security perspective, seeing as how you much more would care about the bytes of memory. I can see how using the strings data could be a particular attack point, but an incorrect size shouldn't be. And we never let the access of our created string outside of the one `.size()` call.

- We don't have to mess with global state/system dependencies by using something like: `std::setlocale`.

---

Overall I think this is the best tradeoff for PGV, but am happy to take any other path as is seen fit.