### PR TITLE
Clean up Bazel build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,114 +1,13 @@
 workspace(name = "com_envoyproxy_protoc_gen_validate")
 
-load('@bazel_tools//tools/build_defs/repo:http.bzl', 'http_archive')
+load("//bazel:repositories.bzl", "pgv_dependencies")
 
-http_archive(
-    name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
-    sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
-)
-http_archive(
-    name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
-    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
-)
-http_archive(
-    name = "com_google_protobuf",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protobuf-all-3.9.1.tar.gz",
-    sha256 = "3040a5b946d9df7aa89c0bf6981330bf92b7844fd90e71b61da0c721e421a421",
-    strip_prefix = "protobuf-3.9.1",
-)
+pgv_dependencies()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("//bazel:dependency_imports.bzl", "pgv_dependency_imports")
 
-protobuf_deps()
+pgv_dependency_imports()
 
+load("//bazel:pip_dependencies.bzl", "pgv_pip_dependencies")
 
-http_archive(
-    name = "bazel_skylib",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
-    sha256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f",
-    strip_prefix = "bazel-skylib-0.5.0",
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
-go_rules_dependencies()
-go_register_toolchains()
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-gazelle_dependencies()
-
-bind(
-    name = "six",
-    actual = "@six_archive//:six",
-)
-
-http_archive(
-    name = "six_archive",
-    build_file = "@com_google_protobuf//:six.BUILD",
-    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
-)
-
-maven_jar(
-    name="com_google_re2j",
-    artifact = "com.google.re2j:re2j:1.2",
-)
-
-maven_jar(
-    name = "com_google_guava",
-    artifact="com.google.guava:guava:27.0-jre",
-)
-bind(
-    name = "guava",
-    actual="@com_google_guava//jar",
-)
-
-maven_jar(
-    name = "com_google_gson",
-    artifact = "com.google.code.gson:gson:2.8.5"
-)
-bind(
-    name = "gson",
-    actual = "@com_google_gson//jar",
-)
-maven_jar(
-    name = "error_prone_annotations_maven",
-    artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
-)
-bind(
-    name = "error_prone_annotations",
-    actual = "@error_prone_annotations_maven//jar",
-)
-
-maven_jar(
-    name = "org_apache_commons_validator",
-    artifact = "commons-validator:commons-validator:1.6"
-)
-
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "io_bazel_rules_python",
-    remote = "https://github.com/bazelbuild/rules_python.git",
-    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
-    shallow_since = "1557865590 -0400",
-)
-
-# Only needed for PIP support:
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories")
-
-pip_repositories()
-
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import")
-
-# This rule translates the specified requirements.txt into
-# @my_deps//:requirements.bzl, which itself exposes a pip_install method.
-pip_import(
-   name = "my_deps",
-   requirements = "//:requirements.txt",
-)
-
-# Load the pip_install symbol for my_deps, and create the dependencies'
-# repositories.
-load("@my_deps//:requirements.bzl", "pip_install")
-pip_install()
+pgv_pip_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,15 +12,18 @@ http_archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
     sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
 )
-# TODO: use released version of protobuf that includes commit
-# fa252ec2a54acb24ddc87d48fed1ecfd458445fd. This works around the issue
-# described here: https://github.com/google/protobuf/pull/5024
 http_archive(
     name = "com_google_protobuf",
-    url = "https://github.com/google/protobuf/archive/fa252ec2a54acb24ddc87d48fed1ecfd458445fd.tar.gz",
-    sha256 = "3d610ac90f8fa16e12490088605c248b85fdaf23114ce4b3605cdf81f7823604",
-    strip_prefix = "protobuf-fa252ec2a54acb24ddc87d48fed1ecfd458445fd",
+    url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protobuf-all-3.9.1.tar.gz",
+    sha256 = "3040a5b946d9df7aa89c0bf6981330bf92b7844fd90e71b61da0c721e421a421",
+    strip_prefix = "protobuf-3.9.1",
 )
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+
 http_archive(
     name = "bazel_skylib",
     url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
@@ -67,6 +70,14 @@ maven_jar(
 bind(
     name = "gson",
     actual = "@com_google_gson//jar",
+)
+maven_jar(
+    name = "error_prone_annotations_maven",
+    artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
+)
+bind(
+    name = "error_prone_annotations",
+    actual = "@error_prone_annotations_maven//jar",
 )
 
 maven_jar(

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -1,0 +1,31 @@
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+
+# Only needed for PIP support:
+
+def _pgv_pip_dependencies():
+    pip_repositories()
+
+    # This rule translates the specified requirements.txt into
+    # @pgv_pip_deps//:requirements.bzl, which itself exposes a pip_install method.
+    pip_import(
+        name = "pgv_pip_deps",
+        requirements = "//:requirements.txt",
+    )
+
+def _pgv_go_dependencies():
+    gazelle_dependencies()
+    go_rules_dependencies()
+    go_register_toolchains()
+
+def pgv_dependency_imports():
+    # Import @com_google_protobuf's dependencies.
+    protobuf_deps()
+
+    # Import @pgv_pip_deps defined by pip's requirements.txt.
+    _pgv_pip_dependencies()
+
+    # Import rules for the Go compiler.
+    _pgv_go_dependencies()

--- a/bazel/pip_dependencies.bzl
+++ b/bazel/pip_dependencies.bzl
@@ -1,0 +1,4 @@
+load("@pgv_pip_deps//:requirements.bzl", "pip_install")
+
+def pgv_pip_dependencies():
+    pip_install()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -1,0 +1,114 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def pgv_dependencies():
+    if not native.existing_rule("io_bazel_rules_go"):
+        http_archive(
+            name = "io_bazel_rules_go",
+            urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
+            sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
+        )
+
+    if not native.existing_rule("bazel_gazelle"):
+        http_archive(
+            name = "bazel_gazelle",
+            urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
+            sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
+        )
+
+    if not native.existing_rule("com_google_protobuf"):
+        http_archive(
+            name = "com_google_protobuf",
+            url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protobuf-all-3.9.1.tar.gz",
+            sha256 = "3040a5b946d9df7aa89c0bf6981330bf92b7844fd90e71b61da0c721e421a421",
+            strip_prefix = "protobuf-3.9.1",
+        )
+
+    # TODO(akonradi): This shouldn't be necesary since the same http_archive block is imported by
+    # protobuf_deps from @com_google_protobuf. Investigate why.
+    if not native.existing_rule("zlib"):
+        http_archive(
+            name = "zlib",
+            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+            strip_prefix = "zlib-1.2.11",
+            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+        )
+
+    if not native.existing_rule("bazel_skylib"):
+        http_archive(
+            name = "bazel_skylib",
+            url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.tar.gz",
+            sha256 = "b5f6abe419da897b7901f90cbab08af958b97a8f3575b0d3dd062ac7ce78541f",
+            strip_prefix = "bazel-skylib-0.5.0",
+        )
+
+    if not native.existing_rule("six"):
+        native.bind(
+            name = "six",
+            actual = "@six_archive//:six",
+        )
+
+    if not native.existing_rule("six_archive"):
+        http_archive(
+            name = "six_archive",
+            build_file = "@com_google_protobuf//:six.BUILD",
+            sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+            url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
+        )
+
+    if not native.existing_rule("com_google_re2j"):
+        native.maven_jar(
+            name = "com_google_re2j",
+            artifact = "com.google.re2j:re2j:1.2",
+        )
+
+    if not native.existing_rule("com_google_guava"):
+        native.maven_jar(
+            name = "com_google_guava",
+            artifact = "com.google.guava:guava:27.0-jre",
+        )
+
+    if not native.existing_rule("guava"):
+        native.bind(
+            name = "guava",
+            actual = "@com_google_guava//jar",
+        )
+
+    if not native.existing_rule("com_google_gson"):
+        native.maven_jar(
+            name = "com_google_gson",
+            artifact = "com.google.code.gson:gson:2.8.5",
+        )
+
+    if not native.existing_rule("gson"):
+        native.bind(
+            name = "gson",
+            actual = "@com_google_gson//jar",
+        )
+
+    if not native.existing_rule("error_prone_annotations_maven"):
+        native.maven_jar(
+            name = "error_prone_annotations_maven",
+            artifact = "com.google.errorprone:error_prone_annotations:2.3.2",
+        )
+
+    if not native.existing_rule("error_prone_annotations"):
+        native.bind(
+            name = "error_prone_annotations",
+            actual = "@error_prone_annotations_maven//jar",
+        )
+
+    if not native.existing_rule("org_apache_commons_validator"):
+        native.maven_jar(
+            name = "org_apache_commons_validator",
+            artifact = "commons-validator:commons-validator:1.6",
+        )
+
+    if not native.existing_rule("io_bazel_rules_python"):
+        git_repository(
+            name = "io_bazel_rules_python",
+            remote = "https://github.com/bazelbuild/rules_python.git",
+            commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
+            shallow_since = "1557865590 -0400",
+        )

--- a/tests/harness/python/BUILD
+++ b/tests/harness/python/BUILD
@@ -1,4 +1,4 @@
-load("@my_deps//:requirements.bzl", "requirement")
+load("@pgv_pip_deps//:requirements.bzl", "requirement")
 load("@io_bazel_rules_python//python:python.bzl",  "py_binary")
 
 


### PR DESCRIPTION
Fix the Bazel build by updating protobuf to v3.9.1, then restructure the loading of external repositories to address #254.