### PR TITLE
undef conflicting symbols on windows

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -15,13 +15,14 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-// <windows.h> uses macros to #define a ton of symbols, two of which (DELETE and GetMessage)
-// interfere with our code. DELETE shows up in the base.pb.h header generated from
-// api/envoy/api/core/base.proto. Since it's a generated header, we can't #undef DELETE at
-// the top of that header to avoid the collision. Similarly, GetMessage shows up in generated
-// protobuf code so we can't #undef the symbol there.
+// <windows.h> uses macros to #define a ton of symbols,
+// many of which interfere with our code here and down
+// the line in various extensions.
 #undef DELETE
+#undef ERROR
 #undef GetMessage
+#undef interface
+#undef TRUE
 
 #endif
 


### PR DESCRIPTION
We found a few more conflicting symbols on Windows (see https://github.com/envoyproxy/protoc-gen-validate/pull/247 for the last few we found).

Relevant [Slack discussion](https://envoyproxy.slack.com/archives/C78HA81DH/p1565360960105300)

Signed-off-by: @wrowe 