### PR TITLE
cc: Convert base file name to screaming snake case

### DIFF
--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -100,6 +100,7 @@ def _protoc_gen_validate_python_impl(ctx):
         package_command = "true",
     )
 
+
 def _protoc_gen_validate_impl(ctx, lang, protos, out_files, protoc_args, package_command):
     protoc_args.append("--plugin=protoc-gen-validate=" + ctx.executable._plugin.path)
 

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -75,7 +75,7 @@ def _protoc_python_output_files(proto_file_sources):
     for p in proto_file_sources:
         basename = p.basename[:-len(".proto")]
 
-        python_srcs.append(basename + "_pb2.py")
+        python_srcs.append(basename.replace("-", "_", maxsplit = None) + "_pb2.py")
     return python_srcs
 
 def _protoc_gen_validate_python_impl(ctx):
@@ -99,7 +99,6 @@ def _protoc_gen_validate_python_impl(ctx):
         protoc_args = args,
         package_command = "true",
     )
-
 
 def _protoc_gen_validate_impl(ctx, lang, protos, out_files, protoc_args, package_command):
     protoc_args.append("--plugin=protoc-gen-validate=" + ctx.executable._plugin.path)

--- a/templates/cc/BUILD.bazel
+++ b/templates/cc/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//templates/shared:go_default_library",
+        "//vendor/github.com/iancoleman/strcase:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star/lang/go:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",

--- a/templates/cc/file.go
+++ b/templates/cc/file.go
@@ -70,7 +70,7 @@ using std::string;
 } // namespace
 {{ end }}
 
-#define X_{{ .Package.ProtoName.ScreamingSnakeCase }}_{{ .File.InputPath.BaseName | upper }}(X) \
+#define X_{{ .Package.ProtoName.ScreamingSnakeCase }}_{{ .File.InputPath.BaseName | screaming_snake_case }}(X) \
 {{ range .AllMessages -}}
 	X({{class . }}) \
 {{ end }}

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -98,7 +98,6 @@ func RegisterHeader(tpl *template.Template, params pgs.Parameters) {
 	tpl.Funcs(map[string]interface{}{
 		"class":                fns.className,
 		"output":               fns.output,
-		"upper":                strings.ToUpper,
 		"screaming_snake_case": strcase.ToScreamingSnake,
 	})
 

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/iancoleman/strcase"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
 )
@@ -95,9 +96,10 @@ func RegisterHeader(tpl *template.Template, params pgs.Parameters) {
 	fns := CCFuncs{pgsgo.InitContext(params)}
 
 	tpl.Funcs(map[string]interface{}{
-		"class":  fns.className,
-		"output": fns.output,
-		"upper":  strings.ToUpper,
+		"class":                fns.className,
+		"output":               fns.output,
+		"upper":                strings.ToUpper,
+		"screaming_snake_case": strcase.ToScreamingSnake,
 	})
 
 	template.Must(tpl.Parse(headerFileTpl))

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -4,9 +4,9 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(
     "//bazel:pgv_proto_library.bzl",
-    "pgv_gogo_proto_library",
-    "pgv_go_proto_library",
     "pgv_cc_proto_library",
+    "pgv_go_proto_library",
+    "pgv_gogo_proto_library",
     "pgv_java_proto_library",
     "pgv_python_proto_library",
 )
@@ -17,6 +17,7 @@ proto_library(
         "bool.proto",
         "bytes.proto",
         "enums.proto",
+        "filename-with-dash.proto",
         "kitchen_sink.proto",
         "maps.proto",
         "messages.proto",
@@ -31,8 +32,8 @@ proto_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//validate:validate_proto",
         "//tests/harness/cases/other_package:embed_proto",
+        "//validate:validate_proto",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -70,34 +71,34 @@ pgv_gogo_proto_library(
 
 pgv_cc_proto_library(
     name = "cc",
-    deps = [":cases_proto"],
     cc_deps = [
         "//tests/harness/cases/other_package:cc",
     ],
     visibility = ["//tests:__subpackages__"],
+    deps = [":cases_proto"],
 )
 
 java_proto_library(
     name = "cases_java_proto",
-    deps = [":cases_proto"],
     visibility = ["//visibility:public"],
+    deps = [":cases_proto"],
 )
 
 pgv_java_proto_library(
     name = "java",
-    deps = [":cases_proto"],
-    visibility = ["//visibility:public"],
     java_deps = [
         ":cases_java_proto",
         "//tests/harness/cases/other_package:java",
     ],
+    visibility = ["//visibility:public"],
+    deps = [":cases_proto"],
 )
 
 pgv_python_proto_library(
     name = "python",
-    deps = [":cases_proto"],
-    visibility = ["//visibility:public"],
     python_deps = [
         "//tests/harness/cases/other_package:python",
     ],
+    visibility = ["//visibility:public"],
+    deps = [":cases_proto"],
 )

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -4,9 +4,9 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(
     "//bazel:pgv_proto_library.bzl",
-    "pgv_cc_proto_library",
-    "pgv_go_proto_library",
     "pgv_gogo_proto_library",
+    "pgv_go_proto_library",
+    "pgv_cc_proto_library",
     "pgv_java_proto_library",
     "pgv_python_proto_library",
 )
@@ -32,8 +32,8 @@ proto_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//tests/harness/cases/other_package:embed_proto",
         "//validate:validate_proto",
+        "//tests/harness/cases/other_package:embed_proto",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -71,34 +71,34 @@ pgv_gogo_proto_library(
 
 pgv_cc_proto_library(
     name = "cc",
+    deps = [":cases_proto"],
     cc_deps = [
         "//tests/harness/cases/other_package:cc",
     ],
     visibility = ["//tests:__subpackages__"],
-    deps = [":cases_proto"],
 )
 
 java_proto_library(
     name = "cases_java_proto",
-    visibility = ["//visibility:public"],
     deps = [":cases_proto"],
+    visibility = ["//visibility:public"],
 )
 
 pgv_java_proto_library(
     name = "java",
+    deps = [":cases_proto"],
+    visibility = ["//visibility:public"],
     java_deps = [
         ":cases_java_proto",
         "//tests/harness/cases/other_package:java",
     ],
-    visibility = ["//visibility:public"],
-    deps = [":cases_proto"],
 )
 
 pgv_python_proto_library(
     name = "python",
+    deps = [":cases_proto"],
+    visibility = ["//visibility:public"],
     python_deps = [
         "//tests/harness/cases/other_package:python",
     ],
-    visibility = ["//visibility:public"],
-    deps = [":cases_proto"],
 )

--- a/tests/harness/cases/filename-with-dash.proto
+++ b/tests/harness/cases/filename-with-dash.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package tests.harness.cases;
+option go_package = "cases";
+
+import "validate/validate.proto";

--- a/tests/harness/cc/harness.cc
+++ b/tests/harness/cc/harness.cc
@@ -15,6 +15,8 @@
 #include "tests/harness/cases/bytes.pb.validate.h"
 #include "tests/harness/cases/enums.pb.h"
 #include "tests/harness/cases/enums.pb.validate.h"
+#include "tests/harness/cases/filename-with-dash.pb.h"
+#include "tests/harness/cases/filename-with-dash.pb.validate.h"
 #include "tests/harness/cases/maps.pb.h"
 #include "tests/harness/cases/maps.pb.validate.h"
 #include "tests/harness/cases/messages.pb.h"

--- a/tests/harness/python/harness.py
+++ b/tests/harness/python/harness.py
@@ -6,6 +6,8 @@ from tests.harness.harness_pb2 import TestCase, TestResult
 from tests.harness.cases.bool_pb2 import *
 from tests.harness.cases.bytes_pb2 import *
 from tests.harness.cases.enums_pb2 import *
+from tests.harness.cases.enums_pb2 import *
+from tests.harness.cases.filename_with_dash_pb2 import *
 from tests.harness.cases.messages_pb2 import *
 from tests.harness.cases.numbers_pb2 import *
 from tests.harness.cases.oneofs_pb2 import *


### PR DESCRIPTION
This patch converts the base file name into `screaming_snake_case` instead
of `upper` for cc macro generation.

This is motivated by:

```
INFO: From Compiling external/com_github_openzipkin_zipkinapi/zipkin-jsonv2.pb.validate.cc:
In file included from bazel-out/k8-opt/bin/external/com_github_openzipkin_zipkinapi/zipkin-jsonv2.pb.validate.cc:5:
bazel-out/k8-opt/bin/external/com_github_openzipkin_zipkinapi/zipkin-jsonv2.pb.validate.h:37:31: warning: ISO C99 requires whitespace after the macro name [-Wc99-extensions]
                              ^
1 warning generated.
```

As reported in
https://github.com/envoyproxy/envoy/pull/6985#issuecomment-526658473.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>