### PR TITLE
build: build fix from bazel version 1.0 update 

### DIFF
--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -84,6 +84,7 @@ def pgv_python_proto_library(
       name: the name of the pgv_python_proto_library
       deps: proto_library rules that contain the necessary .proto files
       python_deps: Python dependencies of the protos being compiled. Likely py_proto_library or pgv_python_proto_library.
+      **kwargs: other keyword arguments that are passed to the py_library.
     """
 
     python_proto_gen_validate(

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -75,7 +75,7 @@ def _protoc_python_output_files(proto_file_sources):
     for p in proto_file_sources:
         basename = p.basename[:-len(".proto")]
 
-        python_srcs.append(basename.replace("-", "_", maxsplit = None) + "_pb2.py")
+        python_srcs.append(basename.replace("-", "_") + "_pb2.py")
     return python_srcs
 
 def _protoc_gen_validate_python_impl(ctx):
@@ -99,7 +99,6 @@ def _protoc_gen_validate_python_impl(ctx):
         protoc_args = args,
         package_command = "true",
     )
-
 
 def _protoc_gen_validate_impl(ctx, lang, protos, out_files, protoc_args, package_command):
     protoc_args.append("--plugin=protoc-gen-validate=" + ctx.executable._plugin.path)
@@ -278,7 +277,7 @@ python_proto_gen_validate = rule(
     attrs = {
         "deps": attr.label_list(
             mandatory = True,
-            providers = ["proto"],
+            providers = [ProtoInfo],
         ),
         "_protoc": attr.label(
             cfg = "host",


### PR DESCRIPTION
This PR updates proto providers to fix PGV build with Bazel 1.0. 

* Bazel 1.0 flipped a flag to disable legacy proto providers, so a rule needs to require a provider from `ProtoInfo` rather than from the provider `"proto"`. See:
https://github.com/bazelbuild/bazel/issues/7152

* Bazel 1.0 updates python so that `maxsplit` is a positional argument. See:
https://github.com/bazelbuild/bazel/issues/9998

Signed-off-by: Asra Ali <asraa@google.com>