### PR TITLE
Do not allocate/copy to a utf-32 string to count a utf-32 len.

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -144,7 +144,7 @@ static inline size_t Utf8Len(const string& narrow_string) {
   size_t unicode_len = 0;
   int char_len = 1;
   while (byte_len > 0 && char_len > 0) {
-    char_len = google:protobuf:UTF8FirstLetterNumBytes(str_char, byte_len);
+    char_len = google::protobuf::UTF8FirstLetterNumBytes(str_char, byte_len);
     str_char += char_len;
     byte_len -= char_len;
     ++unicode_len;

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -136,8 +136,17 @@ static inline bool IsHostname(const string& to_validate) {
 }
 
 static inline size_t Utf8Len(const string& narrow_string) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
-  return converter.from_bytes(narrow_string).size();
+  const char *str_char = narrow_string.c_str();
+  ptrdiff_t byte_len = narrow_string.length();
+  size_t unicode_len = 0;
+  int char_len = 1;
+  while (byte_len > 0 && char_len > 0) {
+    char_len = UTF8FirstLetterNumBytes(str_char, byte_len);
+    str_char += char_len;
+    byte_len -= char_len;
+    ++unicode_len;
+  }
+  return unicode_len;
 }
 
 } // namespace pgv

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -1,7 +1,6 @@
 #ifndef _VALIDATE_H
 #define _VALIDATE_H
 
-#include <codecvt>
 #include <functional>
 #include <regex>
 #include <stdexcept>

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -27,6 +27,8 @@
 
 #endif
 
+#include "google/protobuf/stubs/strutil.h" // for UTF8Len
+
 namespace pgv {
 using std::string;
 

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -144,7 +144,7 @@ static inline size_t Utf8Len(const string& narrow_string) {
   size_t unicode_len = 0;
   int char_len = 1;
   while (byte_len > 0 && char_len > 0) {
-    char_len = UTF8FirstLetterNumBytes(str_char, byte_len);
+    char_len = google:protobuf:UTF8FirstLetterNumBytes(str_char, byte_len);
     str_char += char_len;
     byte_len -= char_len;
     ++unicode_len;


### PR DESCRIPTION
This patch prevents us from allocating temporary strings to count
the string's length in unicode code points, and drops the use of
the deprecated API codecvt introduced in
https://github.com/envoyproxy/protoc-gen-validate/pull/256

It is unclear how we wire this against protobuf's header file,
src/google/protobuf/stubs/strutil.h
so this patch is not ready for merging quite yet.

Resolves a win32 issue of missing char32_t-based codecvt
implementations in their stdlib (win32 favors uchar.)

Signed-off-by: Yechiel Kalmenson <ykalmenson@pivotal.io>
Signed-off-by: William A Rowe Jr <wrowe@pivotal.io>