### PR TITLE
validate: remove use of not operator

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -90,7 +90,7 @@ static inline bool Contains(const string& search_in, const string& to_find)
 
 static inline bool NotContains(const string& search_in, const string& to_find)
 {
-  return not Contains(search_in, to_find);
+  return !Contains(search_in, to_find);
 }
 
 static inline bool IsIpv4(const string& to_validate) {


### PR DESCRIPTION
The C++ not operator is not supported by all compilers.
Use ! instead.

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>