### PR TITLE
Add Buf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ lint:
 	# check for variable shadowing
 	go vet -vettool=$(which shadow) *.go
 	buf check lint
-	buf check breaking --against-input '.git#branch=master' --limit-to-input-files
+	buf check breaking --against-input 'https://github.com/envoyproxy/protoc-gen-validate.git#branch=master' --limit-to-input-files
 
 gogofast:
 	go build -o $@ vendor/github.com/gogo/protobuf/protoc-gen-gogofast/main.go

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,11 @@ lint:
 	# check for variable shadowing
 	go vet -vettool=$(which shadow) *.go
 	buf check lint
-	buf check breaking --against-input 'https://github.com/envoyproxy/protoc-gen-validate.git#branch=master' --limit-to-input-files
+	if [ -d .git ]; then \
+		buf check breaking --against-input '.git#branch=master' --limit-to-input-files; \
+	else \
+		buf check breaking --against-input 'https://github.com/envoyproxy/protoc-gen-validate.git#branch=master' --limit-to-input-files; \
+	fi
 
 gogofast:
 	go build -o $@ vendor/github.com/gogo/protobuf/protoc-gen-gogofast/main.go

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,23 @@
+build:
+  roots:
+    - .
+  excludes:
+    - vendor
+lint:
+  use:
+    - DEFAULT
+  except:
+    - PACKAGE_VERSION_SUFFIX
+  ignore:
+    - gogoproto
+    - java/pgv-java-grpc/src/test/proto
+    - java/pgv-java-stub/src/test/proto
+    - tests
+breaking:
+  use:
+    - FILE
+  ignore:
+    - gogoproto
+    - java/pgv-java-grpc/src/test/proto
+    - java/pgv-java-stub/src/test/proto
+    - tests


### PR DESCRIPTION
Nice library, this is something we all could use as a standard for modern Protobuf development.

There may be no interest in this, and you can close if so, but I added https://buf.build linting and breaking change detection in this PR. This will

- Lint your Protobuf files against a common rule set.
- Check for breaking changes in your Protobuf files on a per-file source code basis.

Some relevant documentation:

- https://buf.build/docs/lint-overview
- https://buf.build/docs/breaking-overview
- https://buf.build/docs/configuration

The `--limit-to-input-files` flag can be removed after the first commit, as the build configuration is needed for proper building of the Protobuf files in this library.

Let me know, I think getting at least breaking change detection in could be really useful.