### PR TITLE
multi errors improvement for golang

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -37,6 +38,7 @@ var (
 	_ = (*url.URL)(nil)
 	_ = (*mail.Address)(nil)
 	_ = ptypes.DynamicAny{}
+	_ = sync.WaitGroup{}
 
 	{{ range (externalEnums .) }}
 		_ = {{ pkg . }}.{{ name . }}(0)

--- a/templates/go/message.go
+++ b/templates/go/message.go
@@ -7,8 +7,8 @@ const messageTpl = `
 	{{ if .MessageRules.GetSkip }}
 		// skipping validation for {{ $f.Name }}
 	{{ else }}
-		if v, ok := interface{}({{ accessor . }}).(interface{ Validate() error }); ok {
-			if err := v.Validate(); err != nil {
+		if v, ok := interface{}({{ accessor . }}).(interface{ Validate{{ if .AllErrors }}All{{ end }}() error }); ok {
+			if err := v.Validate{{ if .AllErrors }}All{{ end }}(); err != nil {
 				return {{ errCause . "err" "embedded message failed validation" }}
 			}
 		}

--- a/templates/gogo/file.go
+++ b/templates/gogo/file.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -37,6 +38,7 @@ var (
 	_ = (*url.URL)(nil)
 	_ = (*mail.Address)(nil)
 	_ = types.DynamicAny{}
+	_ = sync.WaitGroup{}
 
 	{{ range (externalEnums .) }}
 		_ = {{ pkg . }}.{{ name . }}(0)

--- a/templates/shared/context.go
+++ b/templates/shared/context.go
@@ -23,6 +23,8 @@ type RuleContext struct {
 	OnKey            bool
 	Index            string
 	AccessorOverride string
+
+	AllErrors bool
 }
 
 type Gogo struct {
@@ -83,6 +85,7 @@ func (ctx RuleContext) Elem(name, idx string) (out RuleContext, err error) {
 	out.AccessorOverride = name
 	out.Index = idx
 	out.Gogo = ctx.Gogo
+	out.AllErrors = ctx.AllErrors
 
 	var rules *validate.FieldRules
 	switch r := ctx.Rules.(type) {
@@ -122,6 +125,12 @@ func (ctx RuleContext) Unwrap(name string) (out RuleContext, err error) {
 		AccessorOverride: name,
 		Gogo:             ctx.Gogo,
 	}, nil
+}
+
+func (ctx RuleContext) WithAllErrors() (out RuleContext, err error) {
+	out = ctx
+	out.AllErrors = true
+	return
 }
 
 func Render(tpl *template.Template) func(ctx RuleContext) (string, error) {


### PR DESCRIPTION
Hi
Good library. But I would add something:
* Added separate functions for validating each message struct field
* Added function ValidateAll() to message strucs - validation across all message fields and returning a complete list of all errors, including oneOf, repeated, map and embed message

Please see this PR. Perhaps this functionality could be useful not only to me.