### PR TITLE
add field rules to error for golang

### DIFF
--- a/templates/goshared/BUILD.bazel
+++ b/templates/goshared/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//templates/shared:go_default_library",
+        "//validate:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star/lang/go:go_default_library",
         "//vendor/github.com/iancoleman/strcase:go_default_library",

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -45,6 +45,7 @@ func (m {{ (msgTyp .).Pointer }}) Validate() error {
 {{ cmt (errname .) " is the validation error returned by " (msgTyp .) ".Validate if the designated constraints aren't met." -}}
 type {{ errname . }} struct {
 	field  string
+	rules  map[string]interface{}
 	reason string
 	cause  error
 	key    bool
@@ -52,6 +53,9 @@ type {{ errname . }} struct {
 
 // Field function returns field value.
 func (e {{ errname . }}) Field() string { return e.field }
+
+// Rules function returns rules value
+func (e {{ errname . }}) Rules() map[string]interface{} { return e.rules }
 
 // Reason function returns reason value.
 func (e {{ errname . }}) Reason() string { return e.reason }
@@ -89,6 +93,7 @@ var _ error = {{ errname . }}{}
 
 var _ interface{
 	Field() string
+	Rules() map[string]interface{}
 	Reason() string
 	Key() bool
 	Cause() error


### PR DESCRIPTION
Hi

Currently, the reason of validation errors is in text format. This blocks the possibility of creating your error translation mechanism, whether it is a key generation or ready-made translations.

This PR adds field 'rules' to validation error struct. This is necessary to be able to generate your errors.

Please see this PR. Perhaps this functionality could be useful, not only for me.