### PR TITLE
updated gogoproto

### DIFF
--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -81,6 +81,12 @@ extend google.protobuf.FileOptions {
 	optional bool compare_all = 63029;
     optional bool typedecl_all = 63030;
     optional bool enumdecl_all = 63031;
+
+	optional bool goproto_registration = 63032;
+	optional bool messagename_all = 63033;
+
+	optional bool goproto_sizecache_all = 63034;
+	optional bool goproto_unkeyed_all = 63035;
 }
 
 extend google.protobuf.MessageOptions {
@@ -113,6 +119,11 @@ extend google.protobuf.MessageOptions {
 	optional bool compare = 64029;
 
 	optional bool typedecl = 64030;
+
+	optional bool messagename = 64033;
+
+	optional bool goproto_sizecache = 64034;
+	optional bool goproto_unkeyed = 64035;
 }
 
 extend google.protobuf.FieldOptions {
@@ -128,4 +139,6 @@ extend google.protobuf.FieldOptions {
 
 	optional bool stdtime = 65010;
 	optional bool stdduration = 65011;
+	optional bool wktpointer = 65012;
+
 }


### PR DESCRIPTION
The `gogo.proto` file in the root level of the project is missing some fields which our project is using.
This PR just updates the proto file to have said fields.