### PR TITLE
added packages and input paths info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ protoc \
 
 All messages generated include the new `Validate() error` method. PGV requires no additional runtime dependencies from the existing generated code.
 
+**Note**: by default **example.pb.validate.go** is nested in a directory structure that matches your `option go_package` name. You can change this using the protoc parameter `paths=source_relative:.`. Then `--validate_out` will output the file where it is expected. See Google's protobuf documenation or [packages and input paths](https://github.com/golang/protobuf#packages-and-input-paths) or [parameters](https://github.com/golang/protobuf#parameters) for more information.
+
 #### Gogo
 
 There is an experimental support for [gogo
@@ -125,6 +127,8 @@ Gogo support has the following limitations:
 - `gogoproto.nullable` is supported on fields;
 - `gogoproto.stdduration` is supported on fields;
 - `gogoproto.stdtime` is supported on fields;
+
+**Note**: by default **example.pb.validate.go** is nested in a directory structure that matches your `option go_package` name. You can change this using the protoc parameter `paths=source_relative:.`. Then `--validate_out` will output the file where it is expected. See Google's protobuf documenation or [packages and input paths](https://github.com/golang/protobuf#packages-and-input-paths) or [parameters](https://github.com/golang/protobuf#parameters) for more information.
 
 #### Java
 


### PR DESCRIPTION
Ran into the same issue as https://github.com/envoyproxy/protoc-gen-validate/issues/271, so I figured I'd add it to the README.