### PR TITLE
Add _validateUuid method for optional string wrapper

### DIFF
--- a/templates/shared/well_known.go
+++ b/templates/shared/well_known.go
@@ -41,6 +41,10 @@ func Needs(m pgs.Message, wk WellKnown) bool {
 			if strRulesNeeds(rules.GetString_(), wk) {
 				return true
 			}
+		case f.Type().ProtoType() == pgs.MessageT && f.Type().IsEmbed() && f.Type().Embed().WellKnownType() == pgs.StringValueWKT:
+			if strRulesNeeds(rules.GetString_(), wk) {
+				return true
+			}
 		}
 	}
 

--- a/tests/harness/cases/wkt_wrappers.proto
+++ b/tests/harness/cases/wkt_wrappers.proto
@@ -19,4 +19,5 @@ message WrapperString { google.protobuf.StringValue val = 1 [(validate.rules).st
 message WrapperBytes  { google.protobuf.BytesValue val = 1 [(validate.rules).bytes.min_len = 3]; }
 message WrapperRequiredString { google.protobuf.StringValue val = 1 [(validate.rules).string.const = "bar", (validate.rules).message.required = true]; }
 message WrapperRequiredEmptyString { google.protobuf.StringValue val = 1 [(validate.rules).string.const = "", (validate.rules).message.required = true]; }
+message WrapperOptionalUuidString { google.protobuf.StringValue val = 1 [(validate.rules).string.uuid = true, (validate.rules).message.required = false]; }
 message WrapperRequiredFloat { google.protobuf.FloatValue val = 1 [(validate.rules).float.gt = 0, (validate.rules).message.required = true]; }

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -1158,6 +1158,10 @@ var wrapperCases = []TestCase{
 	{"wrapper - required - string (empty) - invalid", &cases.WrapperRequiredEmptyString{Val: &wrappers.StringValue{Value: "foo"}}, false},
 	{"wrapper - required - string (empty) - invalid (empty)", &cases.WrapperRequiredEmptyString{}, false},
 
+	{"wrapper - optional - string (uuid) - valid", &cases.WrapperOptionalUuidString{Val: &wrappers.StringValue{Value: "8b72987b-024a-43b3-b4cf-647a1f925c5d"}}, true},
+	{"wrapper - optional - string (uuid) - valid (empty)", &cases.WrapperOptionalUuidString{}, true},
+	{"wrapper - optional - string (uuid) - invalid", &cases.WrapperOptionalUuidString{Val: &wrappers.StringValue{Value: "foo"}}, false},
+
 	{"wrapper - required - float - valid", &cases.WrapperRequiredFloat{Val: &wrappers.FloatValue{Value: 1}}, true},
 	{"wrapper - required - float - invalid", &cases.WrapperRequiredFloat{Val: &wrappers.FloatValue{Value: -5}}, false},
 	{"wrapper - required - float - invalid (empty)", &cases.WrapperRequiredFloat{}, false},


### PR DESCRIPTION
Fix missing `_validateUuid` method for this example of validation
```
    google.protobuf.StringValue partner_id = 19 [
        (validate.rules).string.uuid = true,
        (validate.rules).message.required = false
    ];
```
