### PR TITLE
generate faster validation code for repeated

### DIFF
--- a/validate/validator.py
+++ b/validate/validator.py
@@ -759,11 +759,14 @@ def repeated_template(option_value, name, field):
             seen.add(item)
     {%- endif %}
     {%- if message_type %}
+    tmp_fn = None
     for item in {{ name }}:
         {%- if o and o.repeated and o.repeated.items.message.skip %}
         pass
         {% else %}
-        validate(item)(item)
+        if tmp_fn is None:
+            tmp_fn = validate(item)
+        tmp_fn(item)
         {% endif %}
     {%- endif %}
     {%- if o and str(o.repeated['items']) %}


### PR DESCRIPTION
When I test boundary value of `repeated.max_items` validation, it was too slow because generated code calls `validate(item)(item)` in the inner loop.
It can be solved by calling `validate(item)` only once.

(.proto file like here)
```
syntax = "proto3";

package example;
import "validate.proto";
import "google/api/annotations.proto";

message M1 {
  string msg = 1 [(validate.rules).string.max_len = 255];
}

message M2 {
  repeated M1 m1s = 1 [(validate.rules).repeated.max_items = 255];
}
```

(test code)
```python
import unittest
from validator import validate, ValidationFailed
from example_pb2 import M2, M1

class TestValid(unittest.TestCase):
    def testM2(self):
        for ok in [M2(m1s=[M1(msg=str(x)) for x in range(254)]),
                   M2(m1s=[M1(msg=str(x)) for x in range(255)])]:
            validate(ok)(ok)

        for ng in [M2(m1s=[M1(msg=str(x)) for x in range(256)]),
                   M2(m1s=[M1(msg=str(x)) for x in range(257)])]:
            with self.assertRaises(ValidationFailed):
                validate(ng)(ng)
```