### PR TITLE
go - support proto field names in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ protoc \
 
 All messages generated include the new `Validate() error` method. PGV requires no additional runtime dependencies from the existing generated code.
 
+The field names reported in the validation error messages are the Go variable names by default. You can change this using the protoc parameter `error_proto_field_name=true`. Then the field names in validation error messages are the proto names.
+
 **Note**: by default **example.pb.validate.go** is nested in a directory structure that matches your `option go_package` name. You can change this using the protoc parameter `paths=source_relative:.`. Then `--validate_out` will output the file where it is expected. See Google's protobuf documenation or [packages and input paths](https://github.com/golang/protobuf#packages-and-input-paths) or [parameters](https://github.com/golang/protobuf#parameters) for more information.
 
 #### Gogo

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -25,7 +25,7 @@ func (m {{ (msgTyp .).Pointer }}) Validate() error {
 				{{ if required . }}
 					default:
 						return {{ errname .Message }}{
-							field: "{{ name . }}",
+							field: "{{ errFieldName . }}",
 							reason: "value is required",
 						}
 				{{ end }}


### PR DESCRIPTION
With the boolean parameter `error_proto_field_name` set to `true` the rendering of error messages uses the proto field names. The parameter defaults to `false`.