### PR TITLE
Add support for external test harness

### DIFF
--- a/tests/harness/executor/harness.go
+++ b/tests/harness/executor/harness.go
@@ -12,12 +12,12 @@ import (
 
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	harness "github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
+	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 )
 
-func Harnesses(goFlag bool, gogoFlag bool, ccFlag bool, javaFlag bool, pythonFlag bool) []Harness {
+func Harnesses(goFlag bool, gogoFlag bool, ccFlag bool, javaFlag bool, pythonFlag bool, externalHarnessFlag string) []Harness {
 	harnesses := make([]Harness, 0)
 	if goFlag {
 		harnesses = append(harnesses, InitHarness("tests/harness/go/main/go-harness"))
@@ -33,6 +33,9 @@ func Harnesses(goFlag bool, gogoFlag bool, ccFlag bool, javaFlag bool, pythonFla
 	}
 	if pythonFlag {
 		harnesses = append(harnesses, InitHarness("tests/harness/python/python-harness"))
+	}
+	if externalHarnessFlag != "" {
+		harnesses = append(harnesses, InitHarness(externalHarnessFlag))
 	}
 	return harnesses
 }


### PR DESCRIPTION
I am building PGV support for [ScalaPB](http://scalapb.github.io). As ScalaPB offers many ways for users to customize the generated code and the generator is written in Scala, it would be impractical to add ScalaPB support directly in here.

We have started to put some effort in https://github.com/scalapb/scalapb-validate and it would be nice to be able to run PGV's test harness against scalapb-validate. To accomplish that, I would like to be able to specify an external program to the harness.

See #322 