### PR TITLE
Fix "SyntaxWarning: "is not" with a literal. Did you mean "!="?"

### DIFF
--- a/validate/validator.py
+++ b/validate/validator.py
@@ -889,7 +889,7 @@ def rule_type(field):
                         str(option_value.double) or str(option_value.uint32) or str(option_value.uint64) or \
                         str(option_value.bool) or str(option_value.string) or str(option_value.bytes):
                     return wrapper_template(option_value, name)
-                elif str(option_value.message) is not "":
+                elif str(option_value.message) != "":
                     return message_template(option_value, field.name)
                 elif str(option_value.any):
                     return any_template(option_value, name)


### PR DESCRIPTION
In Python 3.8:

```
/validate/validator.py:914: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  elif str(option_value.message) is not "":
```

https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/