### PR TITLE
Perform direct calls during message validation

### DIFF
--- a/templates/go/message.go
+++ b/templates/go/message.go
@@ -7,8 +7,8 @@ const messageTpl = `
 	{{ if .MessageRules.GetSkip }}
 		// skipping validation for {{ $f.Name }}
 	{{ else }}
-		if v, ok := interface{}({{ accessor . }}).(interface{ Validate() error }); ok {
-			if err := v.Validate(); err != nil {
+		if _, ok := interface{}({{ accessor . }}).(interface{ Validate() error }); ok {
+			if err := {{ accessor . }}.Validate(); err != nil {
 				return {{ errCause . "err" "embedded message failed validation" }}
 			}
 		}


### PR DESCRIPTION
This helps the compiler by allowing the Validate() call to be potentially inlined - especially if empty.
Unfortunately the compiler is not as smart as it could be so it's unable to completely remove the surrounding `if`.