### PR TITLE
Reduce min go version to go1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,4 @@ clean:
 	rm -rf \
 		tests/harness/cases/go \
 		tests/harness/cases/other_package/go
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/protoc-gen-validate
 
-go 1.14
+go 1.12
 
 require (
 	github.com/golang/protobuf v1.4.2

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/protoc-gen-validate/tests
 
-go 1.14
+go 1.12
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v0.0.0


### PR DESCRIPTION
I believe this should work fine with go1.12 as well. So let's enable support for go modules for go 1.12 users too (like us :))

CI passed all tests