### PR TITLE
Fix C++ oneof validation with _number in name

### DIFF
--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -280,8 +280,7 @@ func (fns CCFuncs) oneofTypeName(f pgs.Field) pgsgo.TypeName {
 	return pgsgo.TypeName(fmt.Sprintf("%s::%sCase::k%s",
 		fns.className(f.Message()),
 		pgsgo.PGGUpperCamelCase(f.OneOf().Name()),
-		pgsgo.PGGUpperCamelCase(f.Name()),
-	))
+		strings.ReplaceAll(pgsgo.PGGUpperCamelCase(f.Name()).String(), "_", "")))
 }
 
 func (fns CCFuncs) inType(f pgs.Field, x interface{}) string {

--- a/tests/harness/cases/oneofs.proto
+++ b/tests/harness/cases/oneofs.proto
@@ -30,5 +30,7 @@ message OneOfRequired {
 
         string       x = 1;
         int32        y = 2;
+        int32        name_with_underscores = 3;
+        int32        under_and_1_number = 4;
     }
 }


### PR DESCRIPTION
The [camelCase implementation](https://github.com/lyft/protoc-gen-star/blob/d607749499f045f8b274bd2f5dd2d04ef4163434/lang/go/camel.go#L31) that PGS uses doesn't replace underscores before numbers, but the protobuf C++ code generator does. Fix and add a test case.

Fixes #372