### PR TITLE
Add support for proto field names in error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,16 @@ bazel-*
 /protoc-gen-validate
 
 /tests/harness/cases/go
+/tests/harness/cases/go_proto_field_name
 /tests/harness/cases/gogo
 /tests/harness/cases/other_package/go
+/tests/harness/cases/other_package/go_proto_field_name
 /tests/harness/cases/other_package/gogo
 /tests/harness/go/harness.pb.go
 /tests/harness/go/main/go-harness
 /tests/harness/go/main/go-harness.exe
+/tests/harness/go/proto_names/go-harness
+/tests/harness/go/proto_names/go-harness.exe
 /tests/harness/gogo/harness.pb.go
 /tests/harness/gogo/main/go-harness
 /tests/harness/gogo/main/go-harness.exe

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ protoc \
 
 All messages generated include the new `Validate() error` method. PGV requires no additional runtime dependencies from the existing generated code.
 
+The field names reported in the validation error messages are the Go variable names by default. You can change this using the protoc parameter `proto_field_name=true`. Then the field names in validation error messages are the proto names.
+
 **Note**: by default **example.pb.validate.go** is nested in a directory structure that matches your `option go_package` name. You can change this using the protoc parameter `paths=source_relative:.`. Then `--validate_out` will output the file where it is expected. See Google's protobuf documenation or [packages and input paths](https://github.com/golang/protobuf#packages-and-input-paths) or [parameters](https://github.com/golang/protobuf#parameters) for more information.
 
 #### Java

--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -4,20 +4,20 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_library")
 load(":protobuf.bzl", "cc_proto_gen_validate", "java_proto_gen_validate", "python_proto_gen_validate")
 
-def pgv_go_proto_library(name, proto = None, deps = [], **kwargs):
+def pgv_go_proto_library(name, proto = None, deps = [], options = [], **kwargs):
     go_proto_compiler(
-        name = "pgv_plugin_go",
+        name = "pgv_plugin_go_" + name,
         suffix = ".pb.validate.go",
         valid_archive = False,
         plugin = "//:protoc-gen-validate",
-        options = ["lang=go"],
+        options = ["lang=go"] + options
     )
 
     go_proto_library(
         name = name,
         proto = proto,
         deps = ["//validate:go_default_library"] + deps,
-        compilers = ["@io_bazel_rules_go//proto:go_proto", "pgv_plugin_go"],
+        compilers = ["@io_bazel_rules_go//proto:go_proto", "pgv_plugin_go_" + name],
         visibility = ["//visibility:public"],
         **kwargs
     )

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -25,7 +25,7 @@ func (m {{ (msgTyp .).Pointer }}) Validate() error {
 				{{ if required . }}
 					default:
 						return {{ errname .Message }}{
-							field: "{{ name . }}",
+							field: "{{ errFieldName . }}",
 							reason: "value is required",
 						}
 				{{ end }}

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -52,6 +52,23 @@ pgv_go_proto_library(
     ],
 )
 
+pgv_go_proto_library(
+    name = "go_proto_field_name",
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go_proto_field_name",
+    proto = ":cases_proto",
+    deps = [
+        ":go",
+        "//tests/harness/cases/other_package:go",
+        "//tests/harness/cases/other_package:go_proto_field_name",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+    ],
+    options = ["proto_field_name=true"],
+)
+
 pgv_cc_proto_library(
     name = "cc",
     cc_deps = [

--- a/tests/harness/cases/other_package/BUILD
+++ b/tests/harness/cases/other_package/BUILD
@@ -30,6 +30,18 @@ pgv_go_proto_library(
     ],
 )
 
+pgv_go_proto_library(
+    name = "go_proto_field_name",
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go_proto_field_name",
+    proto = ":embed_proto",
+    deps = [
+        "//tests/harness/cases/other_package:go",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+    ],
+    options = ["proto_field_name=true"],
+)
+
+
 pgv_cc_proto_library(
     name = "cc",
     visibility = ["//tests:__subpackages__"],

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -34,9 +34,11 @@ go_binary(
     data = ["//tests/harness/cc:cc-harness"] + select({
         ":windows_x86_64": [
             "//tests/harness/go/main:go-harness-exe",
+            "//tests/harness/go/proto_names:go-harness-exe",
         ],
         "//conditions:default": [
             "//tests/harness/go/main:go-harness-bin",
+            "//tests/harness/go/proto_names:go-harness-bin",
             "//tests/harness/java:java-harness",
             "//tests/harness/python:python-harness",
         ],

--- a/tests/harness/executor/harness.go
+++ b/tests/harness/executor/harness.go
@@ -21,6 +21,7 @@ func Harnesses(goFlag, ccFlag, javaFlag, pythonFlag bool, externalHarnessFlag st
 	harnesses := make([]Harness, 0)
 	if goFlag {
 		harnesses = append(harnesses, InitHarness("tests/harness/go/main/go-harness"))
+		harnesses = append(harnesses, InitHarness("tests/harness/go/proto_names/go-harness"))
 	}
 	if ccFlag {
 		harnesses = append(harnesses, InitHarness("tests/harness/cc/cc-harness"))

--- a/tests/harness/go/proto_names/BUILD
+++ b/tests/harness/go/proto_names/BUILD
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["harness.go"],
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/go/proto_names",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//tests/harness:harness_go_proto",
+        "//tests/harness/cases:go",
+        "//tests/harness/cases:go_proto_field_name",
+        "//tests/harness/cases/other_package:go",
+        "//tests/harness/cases/other_package:go_proto_field_name",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
+    ],
+)
+
+genrule(
+    name = "go-harness-bin",
+    srcs = [":main"],
+    outs = ["go-harness"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "go-harness-exe",
+    srcs = [":main"],
+    outs = ["go-harness.exe"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "main",
+    embed = [":go_default_library"],
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/go/proto_names",
+    visibility = ["//visibility:public"],
+)

--- a/tests/harness/go/proto_names/harness.go
+++ b/tests/harness/go/proto_names/harness.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go_proto_field_name"
+	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go_proto_field_name"
+	harness "github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
+)
+
+func main() {
+	b, err := ioutil.ReadAll(os.Stdin)
+	checkErr(err)
+
+	tc := new(harness.TestCase)
+	checkErr(proto.Unmarshal(b, tc))
+
+	da := new(ptypes.DynamicAny)
+	checkErr(ptypes.UnmarshalAny(tc.Message, da))
+	v := da.Message.(interface {
+		Validate() error
+	})
+
+	checkMsg(da.Message, v.Validate())
+}
+
+func checkMsg(message proto.Message, err error) {
+	if err == nil {
+		resp(&harness.TestResult{Valid: true}) // no error means no error message to be checked
+	}
+	fieldError, ok := err.(interface{ Field() string })
+	if !ok {
+		resp(&harness.TestResult{Error: true,
+			Reason: fmt.Sprintf("error does not implement the `interface{ Field() string }`")})
+	}
+	field := fieldError.Field()
+	if field == "" {
+		resp(&harness.TestResult{Error: true,
+			Reason: fmt.Sprintf("error does not contain the field")})
+	}
+	msg := proto.MessageReflect(message)
+	fieldNames := listAllFields(msg)
+	if !contains(field, fieldNames) {
+		resp(&harness.TestResult{Error: true,
+			Reason: fmt.Sprintf("error message '%s' does not contain the field '%s'", err.Error(), field)})
+	}
+	resp(&harness.TestResult{Reason: err.Error()})
+}
+
+func checkErr(err error) {
+	if err == nil {
+		return
+	}
+
+	resp(&harness.TestResult{
+		Error:  true,
+		Reason: err.Error(),
+	})
+}
+
+func resp(result *harness.TestResult) {
+	if b, err := proto.Marshal(result); err != nil {
+		log.Fatalf("could not marshal response: %v", err)
+	} else if _, err = os.Stdout.Write(b); err != nil {
+		log.Fatalf("could not write response: %v", err)
+	}
+	os.Exit(0)
+}
+
+func listAllFields(msg protoreflect.Message) []string {
+	var fieldNames []string
+	fields := msg.Descriptor().Fields()
+	for i := 0; i < fields.Len(); i++ {
+		oneOf := fields.Get(i).ContainingOneof()
+		if oneOf == nil {
+			fieldNames = append(fieldNames, string(fields.Get(i).Name()))
+		} else {
+			fieldNames = append(fieldNames, string(oneOf.Name()))
+			for j := 0; j < oneOf.Fields().Len(); j++ {
+				fieldNames = append(fieldNames, string(oneOf.Fields().Get(i).Name()))
+			}
+		}
+	}
+	return fieldNames
+}
+
+func contains(s string, slice []string) bool {
+	for _, contained := range slice {
+		if strings.Contains(s, contained) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
With the boolean parameter `proto_field_name` set to `true` the rendering of error messages uses the proto field names. The parameter defaults to `false`.

Relates to: #48