### PR TITLE
Fix Validate Function

### DIFF
--- a/tests/harness/python/harness.py
+++ b/tests/harness/python/harness.py
@@ -48,8 +48,7 @@ if __name__ == "__main__":
     test_class = unpack(testcase.message)
     try:
         result = TestResult()
-        valid = validate(test_class)
-        valid(test_class)
+        assert validate(test_class) is None
         result.Valid = True
     except ValidationFailed as e:
         result.Valid = False

--- a/validate/validator.py
+++ b/validate/validator.py
@@ -42,7 +42,7 @@ class ValidatingMessage(object):
             return False
 
 def validate(proto_message):
-    return _validate_inner(ValidatingMessage(proto_message))
+    return _validate_inner(ValidatingMessage(proto_message))(proto_message)
 
 # Cache generated functions to avoid the performance issue caused by repeated proto messages,
 #   which generate the same functions repeatedly.


### PR DESCRIPTION
The following snippet does not return the result of validation but instead the validation function. The patch returns the actual validation result.
```python
def validate(proto_message):
  return _validate_inner(ValidatingMessage(proto_message))
```