### PR TITLE
Create a separate cc_library for proto source

### DIFF
--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -36,6 +36,10 @@ def pgv_cc_proto_library(
       **kargs: other keyword arguments that are passed to cc_library.
     """
 
+    native.cc_proto_library(
+        name = name + "_cc_proto",
+        deps = deps,
+    )
     cc_proto_gen_validate(
         name = name + "_validate",
         deps = deps,
@@ -45,6 +49,7 @@ def pgv_cc_proto_library(
         hdrs = [":" + name + "_validate"],
         srcs = [":" + name + "_validate"],
         deps = cc_deps + [
+            ":" + name + "_cc_proto",
             "@com_envoyproxy_protoc_gen_validate//validate:cc_validate",
             "@com_envoyproxy_protoc_gen_validate//validate:validate_cc",
             "@com_google_protobuf//:protobuf",

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -28,10 +28,8 @@ def _protoc_cc_output_files(proto_file_sources):
     for p in proto_file_sources:
         basename = p.basename[:-len(".proto")]
 
-        cc_hdrs.append(basename + ".pb.h")
         cc_hdrs.append(basename + ".pb.validate.h")
 
-        cc_srcs.append(basename + ".pb.cc")
         cc_srcs.append(basename + ".pb.validate.cc")
 
     return cc_hdrs + cc_srcs
@@ -59,7 +57,6 @@ def _protoc_gen_validate_cc_impl(ctx):
     dir_out = _output_dir(ctx)
 
     args = [
-        "--cpp_out=" + dir_out,
         "--validate_out=lang=cc:" + dir_out,
     ]
 


### PR DESCRIPTION
Since the generated PGV code uses static registration, it needs to be compiled in a cc_library rule with alwayslink set to 1. Before this change, that library also included protobuf code, which means that all generated code for any message type was being included in any consuming binaries. This patch moves the generated .cc and .h files into a separate library that the linker can prune symbols from.