### PR TITLE
Module parameter support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,5 +167,5 @@ clean:
 		tests/harness/cases/go \
 		tests/harness/cases/other_package/go
 	rm -rf \
-		python/dist
+		python/dist \
 		python/*.egg-info

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ testcases: bin/protoc-gen-go
 	protoc \
 		-I . \
 		-I ../../../.. \
-		--go_out="${GO_IMPORT}:./go" \
+		--go_out="module=${PACKAGE}/tests/harness/cases/other_package/go,${GO_IMPORT}:./go" \
 		--plugin=protoc-gen-go=$(shell pwd)/bin/protoc-gen-go \
-		--validate_out="lang=go:./go" \
+		--validate_out="module=${PACKAGE}/tests/harness/cases/other_package/go,lang=go:./go" \
 		./*.proto
 	cd tests/harness/cases && \
 	protoc \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ All messages generated include the new `Validate(all bool) error` method (the `a
 
 **Note**: by default **example.pb.validate.go** is nested in a directory structure that matches your `option go_package` name. You can change this using the protoc parameter `paths=source_relative:.`. Then `--validate_out` will output the file where it is expected. See Google's protobuf documenation or [packages and input paths](https://github.com/golang/protobuf#packages-and-input-paths) or [parameters](https://github.com/golang/protobuf#parameters) for more information.
 
+There's also support for the `module=example.com/foo` flag [described here](https://developers.google.com/protocol-buffers/docs/reference/go-generated#invocation).
+
 #### Java
 
 Java generation is integrated with the existing protobuf toolchain for java projects. For Maven projects, add the

--- a/module/validate.go
+++ b/module/validate.go
@@ -51,7 +51,7 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 			// implementation-specific FilePathFor implementations.
 			// Ex: Don't generate Java validators for files that don't reference PGV.
 			if out != nil {
-				outPath := pgs.JoinPaths(strings.ReplaceAll(out.String(), module, ""))
+				outPath := strings.TrimLeft(strings.ReplaceAll(out.String(), module, ""), "/")
 
 				if opts := f.Descriptor().GetOptions(); opts != nil && opts.GetJavaMultipleFiles() && lang == "java" {
 					// TODO: Only Java supports multiple file generation. If more languages add multiple file generation
@@ -60,7 +60,7 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 						m.AddGeneratorTemplateFile(java.JavaMultiFilePath(f, msg).String(), tpl, msg)
 					}
 				} else {
-					m.AddGeneratorTemplateFile(outPath.String(), tpl, f)
+					m.AddGeneratorTemplateFile(outPath, tpl, f)
 				}
 			}
 		}

--- a/module/validate.go
+++ b/module/validate.go
@@ -5,11 +5,13 @@ import (
 	"github.com/envoyproxy/protoc-gen-validate/templates/java"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"strings"
 )
 
 const (
 	validatorName = "validator"
 	langParam     = "lang"
+	moduleParam   = "module"
 )
 
 type Module struct {
@@ -29,6 +31,7 @@ func (m *Module) Name() string { return validatorName }
 func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Package) []pgs.Artifact {
 	lang := m.Parameters().Str(langParam)
 	m.Assert(lang != "", "`lang` parameter must be set")
+	module := m.Parameters().Str(moduleParam)
 
 	// Process file-level templates
 	tpls := templates.Template(m.Parameters())[lang]
@@ -43,10 +46,13 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 
 		for _, tpl := range tpls {
 			out := templates.FilePathFor(tpl)(f, m.ctx, tpl)
+
 			// A nil path means no output should be generated for this file - as controlled by
 			// implementation-specific FilePathFor implementations.
 			// Ex: Don't generate Java validators for files that don't reference PGV.
 			if out != nil {
+				outPath := pgs.JoinPaths(strings.ReplaceAll(out.String(), module, ""))
+
 				if opts := f.Descriptor().GetOptions(); opts != nil && opts.GetJavaMultipleFiles() && lang == "java" {
 					// TODO: Only Java supports multiple file generation. If more languages add multiple file generation
 					// support, the implementation should be made more inderect.
@@ -54,7 +60,7 @@ func (m *Module) Execute(targets map[string]pgs.File, pkgs map[string]pgs.Packag
 						m.AddGeneratorTemplateFile(java.JavaMultiFilePath(f, msg).String(), tpl, msg)
 					}
 				} else {
-					m.AddGeneratorTemplateFile(out.String(), tpl, f)
+					m.AddGeneratorTemplateFile(outPath.String(), tpl, f)
 				}
 			}
 		}

--- a/tests/harness/cases/other_package/embed.proto
+++ b/tests/harness/cases/other_package/embed.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package tests.harness.cases.other_package;
-option go_package = "other_package";
+option go_package = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go;other_package";
 
 import "validate/validate.proto";
 


### PR DESCRIPTION
Adds support for the `module=example.com/foo` flag [described here](https://developers.google.com/protocol-buffers/docs/reference/go-generated#invocation).

This flag "strips" of the provided prefix from the output path. In effect it makes it possible to output the generated files in any sub folder, but the import paths, module and packages "line up".

Fixes #342