### PR TITLE
Fix JavaHarness and test executor's results summation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ bazel-*
 .classpath
 .settings
 .idea/
+.ijwb/

--- a/tests/harness/executor/harness.go
+++ b/tests/harness/executor/harness.go
@@ -20,19 +20,19 @@ import (
 func Harnesses(goFlag, ccFlag, javaFlag, pythonFlag bool, externalHarnessFlag string) []Harness {
 	harnesses := make([]Harness, 0)
 	if goFlag {
-		harnesses = append(harnesses, InitHarness("tests/harness/go/main/go-harness"))
+		harnesses = append(harnesses, InitHarness("tests/harness/go/main/go-harness", "go"))
 	}
 	if ccFlag {
-		harnesses = append(harnesses, InitHarness("tests/harness/cc/cc-harness"))
+		harnesses = append(harnesses, InitHarness("tests/harness/cc/cc-harness", "cc"))
 	}
 	if javaFlag {
-		harnesses = append(harnesses, InitHarness("tests/harness/java/java-harness"))
+		harnesses = append(harnesses, InitHarness("tests/harness/java/java-harness", "java"))
 	}
 	if pythonFlag {
-		harnesses = append(harnesses, InitHarness("tests/harness/python/python-harness"))
+		harnesses = append(harnesses, InitHarness("tests/harness/python/python-harness", "python"))
 	}
 	if externalHarnessFlag != "" {
-		harnesses = append(harnesses, InitHarness(externalHarnessFlag))
+		harnesses = append(harnesses, InitHarness(externalHarnessFlag, "external"))
 	}
 	return harnesses
 }
@@ -42,7 +42,7 @@ type Harness struct {
 	Exec func(context.Context, io.Reader) (*harness.TestResult, error)
 }
 
-func InitHarness(cmd string, args ...string) Harness {
+func InitHarness(cmd string, name string, args ...string) Harness {
 	if runtime.GOOS == "windows" {
 		// Bazel runfiles are not symlinked in on windows,
 		// so we have to use the manifest instead. If the manifest
@@ -66,7 +66,7 @@ func InitHarness(cmd string, args ...string) Harness {
 	}
 
 	return Harness{
-		Name: cmd,
+		Name: name,
 		Exec: initHarness(cmd, args...),
 	}
 }

--- a/validate/validator.py
+++ b/validate/validator.py
@@ -976,17 +976,12 @@ def rule_type(field):
 
 def file_template(proto_message):
     file_tmp = """
-{%- set ns = namespace(ignored=false) -%}
-{%- for option_descriptor, option_value in p.DESCRIPTOR.GetOptions().ListFields() -%}
-    {%- if option_descriptor.full_name == "validate.ignored" and option_value -%}
-        {%- set ns.found = true -%}
-    {%- endif -%}
-{%- endfor -%}
-{%- if not ns.ignored -%}
 # Validates {{ p.DESCRIPTOR.name }}
 def generate_validate(p):
     {%- for option_descriptor, option_value in p.DESCRIPTOR.GetOptions().ListFields() %}
         {%- if option_descriptor.full_name == "validate.disabled" and option_value %}
+    return None
+        {%- elif option_descriptor.full_name == "validate.ignored" and option_value %}
     return None
         {%- endif -%}
     {%- endfor -%}
@@ -1009,9 +1004,7 @@ def generate_validate(p):
     {{ rule_type(field) -}}
         {%- endif %}
     {%- endfor %}
-    return None
-{%- endif -%}
-"""
+    return None"""
     return Template(file_tmp).render(rule_type = rule_type, p = proto_message)
 
 class UnimplementedException(Exception):


### PR DESCRIPTION
There's a bug in the way test failures are added up. If any harness returns a skipped test result, test failures in other harnesses are also ignored. This has been showing up in the master build, see `message - ignored - valid` and `message - ignored - valid (invalid field)` cases. Since `cc` skipped these cases, failures in python and java were ignored. 

Have fixed python and java, and have changed the test worker to report problems to the out channel per-harness-per-test-case, instead of only per-test-case.