### PR TITLE
List validator.py as a dependency for py harness

### DIFF
--- a/tests/harness/python/BUILD
+++ b/tests/harness/python/BUILD
@@ -5,10 +5,12 @@ py_binary(
     name = "python-harness",
     srcs = ["harness.py"],
     main = "harness.py",
+    srcs_version = "PY3",
     visibility = ["//tests/harness:__subpackages__"],
     deps = [
         "//tests/harness:python-harness-proto",
         "//tests/harness/cases:python",
+        "//validate:validator_py",
         requirement("validate-email"),
         requirement("ipaddress"),
         requirement("Jinja2"),

--- a/tests/harness/python/harness.py
+++ b/tests/harness/python/harness.py
@@ -20,8 +20,7 @@ from tests.harness.cases.wkt_wrappers_pb2 import *
 from tests.harness.cases.wkt_timestamp_pb2 import *
 from tests.harness.cases.kitchen_sink_pb2 import *
 
-sys.path.append(os.environ['GOPATH']+'/src/github.com/envoyproxy/protoc-gen-validate/validate')
-from validator import validate, ValidationFailed, UnimplementedException, print_validate
+from validate.validator import validate, ValidationFailed, UnimplementedException, print_validate
 
 class_list = []
 for k, v in inspect.getmembers(sys.modules[__name__], inspect.isclass):

--- a/validate/BUILD
+++ b/validate/BUILD
@@ -4,10 +4,14 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
 load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+package(
+    default_visibility =
+        ["//visibility:public"],
+)
+
 proto_library(
     name = "validate_proto",
     srcs = ["validate.proto"],
-    visibility = ["//visibility:public"],
     deps = [
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:duration_proto",
@@ -17,7 +21,6 @@ proto_library(
 
 cc_proto_library(
     name = "validate_cc",
-    visibility = ["//visibility:public"],
     deps = [":validate_proto"],
 )
 
@@ -26,7 +29,6 @@ py_proto_library(
     srcs = ["validate.proto"],
     default_runtime = "@com_google_protobuf//:protobuf_python",
     protoc = "@com_google_protobuf//:protoc",
-    visibility = ["//visibility:public"],
     deps = ["@com_google_protobuf//:protobuf_python"],
 )
 
@@ -34,17 +36,20 @@ go_proto_library(
     name = "go_default_library",
     importpath = "github.com/envoyproxy/protoc-gen-validate/validate",
     proto = ":validate_proto",
-    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "cc_validate",
     hdrs = ["validate.h"],
-    visibility = ["//visibility:public"],
 )
 
 java_proto_library(
     name = "validate_java",
-    visibility = ["//visibility:public"],
     deps = [":validate_proto"],
+)
+
+py_library(
+    name = "validator_py",
+    srcs = ["validator.py"],
+    srcs_version = "PY3",
 )


### PR DESCRIPTION
Instead of hackily adjusting the Python path during execution, create a
py_library rule for validator.py and list it as a dependency of the
python harness binary.