### PR TITLE
Make test executor a statically-linked executable

### DIFF
--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -41,6 +41,12 @@ go_binary(
             "//tests/harness/python:python-harness",
         ],
     }),
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     embed = [":go_default_library"],
     importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/executor",
     visibility = ["//visibility:private"],


### PR DESCRIPTION
https://github.com/scalapb/scalapb-validate relies on PGV's test executor to drive its tests. For better local development experience and easier CI testing, I'd like to have a pre-built statically linked executable for the executor so it can be used on different Linux distros.

Some more background: up until recently, a simple `bazel build tests/harness/executor` was sufficient to get the executor built on both OS X and Linux, locally and on Github Actions. I am not sure what had changed (maybe the ubuntu image on Github?) but I've been running into [different build errors involving bazel, go and protoc](https://github.com/scalapb/scalapb-validate/runs/2181243519?check_suite_focus=true). In interest of saving time debugging this, my preference is to use the Dockerfile provided with PGV for a reproducible build of the executor, and possibly extract it out of the image for local usage. To make sure it works across distros it should be statically linked.
