### PR TITLE
Bump apache commons-validator:1.7

### DIFF
--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
@@ -146,6 +146,7 @@ public class StringValidationTest {
         StringValidation.email("x", "foo@bar.com");
         StringValidation.email("x", "John Smith <foo@bar.com>");
         StringValidation.email("x", "John Doe <john.\"we<i<>r>do\".doe@example.com>");
+        StringValidation.email("x", "john@foo.africa");
         // No Match
         assertThatThrownBy(() -> StringValidation.email("x", "bar.bar.bar")).isInstanceOf(ValidationException.class);
         assertThatThrownBy(() -> StringValidation.email("x", "John Doe <john.doe@example.com")).isInstanceOf(ValidationException.class);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,7 +44,7 @@
 
         <protoc.version>3.5.1</protoc.version>
         <re2j.version>1.2</re2j.version>
-        <commons.validator.version>1.6</commons.validator.version>
+        <commons.validator.version>1.7</commons.validator.version>
         <google.protobuf.version>3.6.1</google.protobuf.version>
         <grpc.version>1.12.0</grpc.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
The email validation is too restrictive. For example `some@email.africa` is considered as invalid.

This PR bumps commons-validator to the last version: [1.7](https://commons.apache.org/proper/commons-validator/changes-report.html#a1.7) (2020-08-07). The previous version (1.6) was rather old (2017-02-21).

Domain validation and thus email validation have been improved by this release.