### PR TITLE
Fix indentation in python codegen for required oneof

### DIFF
--- a/python/protoc_gen_validate/validator.py
+++ b/python/protoc_gen_validate/validator.py
@@ -287,7 +287,7 @@ def string_template(option_value, name):
 
 
 def required_template(value, name):
-    req_tmpl = """{%- if value['required'] -%}
+    req_tmpl = """{%- if value['required'] %}
     if not _has_field(p, \"{{ name.split('.')[-1] }}\"):
         raise ValidationFailed(\"{{ name }} is required.\")
     {%- endif -%}

--- a/tests/harness/cases/messages.proto
+++ b/tests/harness/cases/messages.proto
@@ -32,4 +32,11 @@ message MessageCrossPackage { tests.harness.cases.other_package.Embed val = 1; }
 message MessageSkip { TestMsg val = 1 [(validate.rules).message.skip = true];}
 message MessageRequired { TestMsg val = 1 [(validate.rules).message.required = true]; }
 
+message MessageRequiredOneof {
+    oneof one {
+        option (validate.required) = true;
+        TestMsg val = 1 [(validate.rules).message.required = true];
+    }
+}
+
 message MessageWith3dInside {}

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -1049,7 +1049,9 @@ var messageCases = []TestCase{
 	{"message - skip - valid", &cases.MessageSkip{Val: &cases.TestMsg{}}, true},
 
 	{"message - required - valid", &cases.MessageRequired{Val: &cases.TestMsg{Const: "foo"}}, true},
+	{"message - required - valid (oneof)", &cases.MessageRequiredOneof{One: &cases.MessageRequiredOneof_Val{&cases.TestMsg{Const: "foo"}}}, true},
 	{"message - required - invalid", &cases.MessageRequired{}, false},
+	{"message - required - invalid (oneof)", &cases.MessageRequiredOneof{}, false},
 
 	{"message - cross-package embed none - valid", &cases.MessageCrossPackage{Val: &other_package.Embed{Val: 1}}, true},
 	{"message - cross-package embed none - valid (nil)", &cases.MessageCrossPackage{}, true},


### PR DESCRIPTION
A trailing `-%}` will remove whitespace before the next non-whitespace character. This lead to indentation issue in the generated code:

```
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_jfish/952dee0bae9a937b66c9760a1a3bb297/sandbox/darwin-sandbox/26/execroot/com_envoyproxy_protoc_gen_validate/bazel-out/darwin-fastbuild/bin/tests/harness/executor/executor_python_test.runfiles/com_envoyproxy_protoc_gen_validate/tests/harness/python/harness.py", line 42, in <module>
    valid = validate(test_msg)
  File "/private/var/tmp/_bazel_jfish/952dee0bae9a937b66c9760a1a3bb297/sandbox/darwin-sandbox/26/execroot/com_envoyproxy_protoc_gen_validate/bazel-out/darwin-fastbuild/bin/tests/harness/executor/executor_python_test.runfiles/com_envoyproxy_protoc_gen_validate/python/protoc_gen_validate/validator.py", line 50, in validate
    return _validate_inner(ValidatingMessage(proto_message))(proto_message)
  File "/private/var/tmp/_bazel_jfish/952dee0bae9a937b66c9760a1a3bb297/sandbox/darwin-sandbox/26/execroot/com_envoyproxy_protoc_gen_validate/bazel-out/darwin-fastbuild/bin/tests/harness/executor/executor_python_test.runfiles/com_envoyproxy_protoc_gen_validate/python/protoc_gen_validate/validator.py", line 59, in _validate_inner
    exec(func)
  File "<string>", line 7
    if not _has_field(p, "val"):
IndentationError: unexpected indent
[message - required - invalid (oneof)] (python harness) executor error: [tests/harness/python/python-harness tests/harness/python/python-harness] failed execution (exit status 1) - captured stderr:
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_jfish/952dee0bae9a937b66c9760a1a3bb297/sandbox/darwin-sandbox/26/execroot/com_envoyproxy_protoc_gen_validate/bazel-out/darwin-fastbuild/bin/tests/harness/executor/executor_python_test.runfiles/com_envoyproxy_protoc_gen_validate/tests/harness/python/harness.py", line 42, in <module>
    valid = validate(test_msg)
  File "/private/var/tmp/_bazel_jfish/952dee0bae9a937b66c9760a1a3bb297/sandbox/darwin-sandbox/26/execroot/com_envoyproxy_protoc_gen_validate/bazel-out/darwin-fastbuild/bin/tests/harness/executor/executor_python_test.runfiles/com_envoyproxy_protoc_gen_validate/python/protoc_gen_validate/validator.py", line 50, in validate
    return _validate_inner(ValidatingMessage(proto_message))(proto_message)
  File "/private/var/tmp/_bazel_jfish/952dee0bae9a937b66c9760a1a3bb297/sandbox/darwin-sandbox/26/execroot/com_envoyproxy_protoc_gen_validate/bazel-out/darwin-fastbuild/bin/tests/harness/executor/executor_python_test.runfiles/com_envoyproxy_protoc_gen_validate/python/protoc_gen_validate/validator.py", line 59, in _validate_inner
    exec(func)
  File "<string>", line 7
    if not _has_field(p, "val"):
IndentationError: unexpected indent
``` 