### PR TITLE
Python: Use std library `ipaddress` instead of legacy pypi backport package

### DIFF
--- a/python/requirements.in
+++ b/python/requirements.in
@@ -1,7 +1,6 @@
 # These must be the same as the requirements listed in
 # install_requires section of setup.cfg. A test checks for this.
 # See requirements_test.py for more context.
-ipaddress>=1.0.22
 validate-email>=1.3
 Jinja2>=2.11.1
 protobuf>=3.6.1

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    ipaddress>=1.0.22
     validate-email>=1.3
     Jinja2>=2.11.1
     protobuf>=3.6.1


### PR DESCRIPTION
[ipaddress](https://pypi.org/project/ipaddress/) from PyPi is an out of date backport of the [ipaddress module](https://docs.python.org/3/library/ipaddress.html) in the standard library that is designed to support Python versions < 3.3.

Since this project requires python 3.6, we should be able to use the stdlib and drop this package as a dependency.

This issue arose due vulnerability scanner indicating that [ipaddress](https://pypi.org/project/ipaddress/) from PyPi was 'high risk'.