### PR TITLE
Added nil check for oneof type

### DIFF
--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -34,7 +34,7 @@ func (m {{ (msgTyp .).Pointer }}) validate(all bool) error {
 		{{ end }}
 
 		{{ range .OneOfs }}
-			if m.{{ name }}.(type) == nil { return nil }
+			if m.Type == nil { return nil }
 			
 			switch m.{{ name . }}.(type) {
 				{{ range .Fields }}

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -34,7 +34,7 @@ func (m {{ (msgTyp .).Pointer }}) validate(all bool) error {
 		{{ end }}
 
 		{{ range .OneOfs }}
-			if m.Type == nil { return nil }
+			if m.{{ name . }} == nil { return nil }
 			
 			switch m.{{ name . }}.(type) {
 				{{ range .Fields }}

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -34,6 +34,8 @@ func (m {{ (msgTyp .).Pointer }}) validate(all bool) error {
 		{{ end }}
 
 		{{ range .OneOfs }}
+			if m.{{ name }}.(type) == nil { return nil }
+			
 			switch m.{{ name . }}.(type) {
 				{{ range .Fields }}
 					case {{ oneof . }}:


### PR DESCRIPTION
### Description
For protobuf messages containing a `oneof` enum as a field, the generated Go "validate" code contains an enum interface that is implemented by structs, one for each variant in the `oneof`. Then, a struct message is generated, with a `Type` field containing a value of the aforementioned enum interface. 
The `Type` field can be `nil`, and has been observed to be nil. This is not checked by the validation code, so the service crashes when a request is made.

## Change
Added a `nil` check for `Type` to the `oneof` generation code