### PR TITLE
Added nil check to oneof type

### DIFF
--- a/templates/cc/msg.go
+++ b/templates/cc/msg.go
@@ -103,6 +103,8 @@ bool Validate(const {{ class . }}& m, pgv::ValidationMsg* err) {
 			{{- render (context .) -}}
 		{{ end -}}
 		{{ range .OneOfs }}
+			if (m.{{ .Name }}_case() == 0) { return false; }
+			
 			switch (m.{{ .Name }}_case()) {
 				{{ range .Fields -}}
 					case {{ oneof . }}:

--- a/templates/cc/msg.go
+++ b/templates/cc/msg.go
@@ -103,8 +103,10 @@ bool Validate(const {{ class . }}& m, pgv::ValidationMsg* err) {
 			{{- render (context .) -}}
 		{{ end -}}
 		{{ range .OneOfs }}
-			if (m.{{ .Name }}_case() == 0) { return false; }
-			
+			{{- if required . }}
+				if (m.{{ .Name }}_case() == 0) { return false; }
+			{{ end }}
+
 			switch (m.{{ .Name }}_case()) {
 				{{ range .Fields -}}
 					case {{ oneof . }}:

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -34,14 +34,16 @@ func (m {{ (msgTyp .).Pointer }}) validate(all bool) error {
 		{{ end }}
 
 		{{ range .OneOfs }}
-			if m.{{ name . }} == nil { 
-				err := {{ errname .Message }}{
-					field: "m.{{ name . }}",
-					reason: "field must not be nil",
+			{{ if required . }}
+				if m.{{ name . }} == nil { 
+					err := {{ errname .Message }}{
+						field: "m.{{ name . }}",
+						reason: "field must not be nil",
+					}
+					if !all { return err }
+					errors = append(errors, err)
 				}
-				if !all { return err }
-				errors = append(errors, err)
-			}
+			{{ end }}
 
 			switch m.{{ name . }}.(type) {
 				{{ range .Fields }}

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -34,6 +34,8 @@ func (m {{ (msgTyp .).Pointer }}) validate(all bool) error {
 		{{ end }}
 
 		{{ range .OneOfs }}
+			if m.{{ name . }} == nil { return nil }
+
 			switch m.{{ name . }}.(type) {
 				{{ range .Fields }}
 					case {{ oneof . }}:

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -34,7 +34,14 @@ func (m {{ (msgTyp .).Pointer }}) validate(all bool) error {
 		{{ end }}
 
 		{{ range .OneOfs }}
-			if m.{{ name . }} == nil { return nil }
+			if m.{{ name . }} == nil { 
+				err := {{ errname .Message }}{
+					field: "m.{{ name . }}",
+					reason: "field must not be nil",
+				}
+				if !all { return err }
+				errors = append(errors, err)
+			}
 
 			switch m.{{ name . }}.(type) {
 				{{ range .Fields }}

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -16,6 +16,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/lyft/protoc-gen-star v0.5.1/go.mod h1:9toiA3cC7z5uVbODF7kEQ91Xn7XNFkVUl+SrEe+ZORU=
+github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -1175,18 +1175,19 @@ var mapCases = []TestCase{
 
 var oneofCases = []TestCase{
 	{"oneof - none - valid", &cases.OneOfNone{O: &cases.OneOfNone_X{X: "foo"}}, 0},
-	{"oneof - none - invalid (empty)", &cases.OneOfNone{}, 1},
+	{"oneof - none - valid (empty)", &cases.OneOfNone{}, 0},
 
 	{"oneof - field - valid (X)", &cases.OneOf{O: &cases.OneOf_X{X: "foobar"}}, 0},
 	{"oneof - field - valid (Y)", &cases.OneOf{O: &cases.OneOf_Y{Y: 123}}, 0},
 	{"oneof - field - valid (Z)", &cases.OneOf{O: &cases.OneOf_Z{Z: &cases.TestOneOfMsg{Val: true}}}, 0},
-	{"oneof - field - invalid (empty)", &cases.OneOf{}, 1},
+	{"oneof - field - valid (empty)", &cases.OneOf{}, 0},
 	{"oneof - field - invalid (X)", &cases.OneOf{O: &cases.OneOf_X{X: "fizzbuzz"}}, 1},
 	{"oneof - field - invalid (Y)", &cases.OneOf{O: &cases.OneOf_Y{Y: -1}}, 1},
 	{"oneof - field - invalid (Z)", &cases.OneOf{O: &cases.OneOf_Z{Z: &cases.TestOneOfMsg{}}}, 1},
 
 	{"oneof - required - valid", &cases.OneOfRequired{O: &cases.OneOfRequired_X{X: ""}}, 0},
 	{"oneof - require - invalid", &cases.OneOfRequired{}, 1},
+	{"oneof - none - invalid", &cases.OneOfRequired{O: nil}, 1},
 }
 
 var wrapperCases = []TestCase{

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -1175,15 +1175,15 @@ var mapCases = []TestCase{
 
 var oneofCases = []TestCase{
 	{"oneof - none - valid", &cases.OneOfNone{O: &cases.OneOfNone_X{X: "foo"}}, 0},
-	{"oneof - none - valid (empty)", &cases.OneOfNone{}, 0},
+	{"oneof - none - invalid (empty)", &cases.OneOfNone{}, 1},
 
 	{"oneof - field - valid (X)", &cases.OneOf{O: &cases.OneOf_X{X: "foobar"}}, 0},
 	{"oneof - field - valid (Y)", &cases.OneOf{O: &cases.OneOf_Y{Y: 123}}, 0},
 	{"oneof - field - valid (Z)", &cases.OneOf{O: &cases.OneOf_Z{Z: &cases.TestOneOfMsg{Val: true}}}, 0},
-	{"oneof - field - valid (empty)", &cases.OneOf{}, 0},
+	{"oneof - field - invalid (empty)", &cases.OneOf{}, 1},
 	{"oneof - field - invalid (X)", &cases.OneOf{O: &cases.OneOf_X{X: "fizzbuzz"}}, 1},
 	{"oneof - field - invalid (Y)", &cases.OneOf{O: &cases.OneOf_Y{Y: -1}}, 1},
-	{"oneof - filed - invalid (Z)", &cases.OneOf{O: &cases.OneOf_Z{Z: &cases.TestOneOfMsg{}}}, 1},
+	{"oneof - field - invalid (Z)", &cases.OneOf{O: &cases.OneOf_Z{Z: &cases.TestOneOfMsg{}}}, 1},
 
 	{"oneof - required - valid", &cases.OneOfRequired{O: &cases.OneOfRequired_X{X: ""}}, 0},
 	{"oneof - require - invalid", &cases.OneOfRequired{}, 1},


### PR DESCRIPTION
### Description
For protobuf messages containing a `oneof` enum as a field, the generated Go "validate" code contains an enum interface that is implemented by structs, one for each variant in the `oneof`. Then, a struct message is generated, with a `Type` field containing a value of the aforementioned enum interface. 
The `Type` field can be `nil`, and has been observed to be nil. This is not checked by the validation code, so the service crashes when a request is made.

In our service the issue was that `m.Type` was nil, so when it was used in the switch case it failed:
```
switch m.Type(type) {...}
```

My change has resulted in the following being added to the generated validate code:
```
if m.Type == nil {return nil}
switch m.Type(type) {...}
```

so the nil Type is caught early and the service no longer crashes.

Please let me know if further info is required.

## Change
Added a `nil` check for `Type` to the `oneof` generation code

Signed-off-by: Mila <milakosc@gmail.com>