### PR TITLE
Fix ignore_empty test cases.

### DIFF
--- a/tests/harness/cases/numbers.proto
+++ b/tests/harness/cases/numbers.proto
@@ -30,7 +30,7 @@ message DoubleGTLT     { double val = 1 [(validate.rules).double = {gt: 0, lt: 1
 message DoubleExLTGT   { double val = 1 [(validate.rules).double = {lt: 0, gt: 10}]; }
 message DoubleGTELTE   { double val = 1 [(validate.rules).double = {gte: 128, lte: 256}]; }
 message DoubleExGTELTE { double val = 1 [(validate.rules).double = {lte: 128, gte: 256}]; }
-message DoubleIgnore   { double val = 1 [(validate.rules).double = {lte: 128, gte: 256, ignore_empty: true}]; }
+message DoubleIgnore   { double val = 1 [(validate.rules).double = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message Int32None     { int32 val = 1; }
 message Int32Const    { int32 val = 1 [(validate.rules).int32.const = 1]; }
@@ -44,7 +44,7 @@ message Int32GTLT     { int32 val = 1 [(validate.rules).int32 = {gt: 0, lt: 10}]
 message Int32ExLTGT   { int32 val = 1 [(validate.rules).int32 = {lt: 0, gt: 10}]; }
 message Int32GTELTE   { int32 val = 1 [(validate.rules).int32 = {gte: 128, lte: 256}]; }
 message Int32ExGTELTE { int32 val = 1 [(validate.rules).int32 = {lte: 128, gte: 256}]; }
-message Int32Ignore   { int32 val = 1 [(validate.rules).int32 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message Int32Ignore   { int32 val = 1 [(validate.rules).int32 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message Int64None     { int64 val = 1; }
 message Int64Const    { int64 val = 1 [(validate.rules).int64.const = 1]; }
@@ -58,7 +58,7 @@ message Int64GTLT     { int64 val = 1 [(validate.rules).int64 = {gt: 0, lt: 10}]
 message Int64ExLTGT   { int64 val = 1 [(validate.rules).int64 = {lt: 0, gt: 10}]; }
 message Int64GTELTE   { int64 val = 1 [(validate.rules).int64 = {gte: 128, lte: 256}]; }
 message Int64ExGTELTE { int64 val = 1 [(validate.rules).int64 = {lte: 128, gte: 256}]; }
-message Int64Ignore   { int64 val = 1 [(validate.rules).int64 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message Int64Ignore   { int64 val = 1 [(validate.rules).int64 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message UInt32None     { uint32 val = 1; }
 message UInt32Const    { uint32 val = 1 [(validate.rules).uint32.const = 1]; }
@@ -72,7 +72,7 @@ message UInt32GTLT     { uint32 val = 1 [(validate.rules).uint32 = {gt: 5, lt: 1
 message UInt32ExLTGT   { uint32 val = 1 [(validate.rules).uint32 = {lt: 5, gt: 10}]; }
 message UInt32GTELTE   { uint32 val = 1 [(validate.rules).uint32 = {gte: 128, lte: 256}]; }
 message UInt32ExGTELTE { uint32 val = 1 [(validate.rules).uint32 = {lte: 128, gte: 256}]; }
-message UInt32Ignore   { uint32 val = 1 [(validate.rules).uint32 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message UInt32Ignore   { uint32 val = 1 [(validate.rules).uint32 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message UInt64None     { uint64 val = 1; }
 message UInt64Const    { uint64 val = 1 [(validate.rules).uint64.const = 1]; }
@@ -86,7 +86,7 @@ message UInt64GTLT     { uint64 val = 1 [(validate.rules).uint64 = {gt: 5, lt: 1
 message UInt64ExLTGT   { uint64 val = 1 [(validate.rules).uint64 = {lt: 5, gt: 10}]; }
 message UInt64GTELTE   { uint64 val = 1 [(validate.rules).uint64 = {gte: 128, lte: 256}]; }
 message UInt64ExGTELTE { uint64 val = 1 [(validate.rules).uint64 = {lte: 128, gte: 256}]; }
-message UInt64Ignore   { uint64 val = 1 [(validate.rules).uint64 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message UInt64Ignore   { uint64 val = 1 [(validate.rules).uint64 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message SInt32None     { sint32 val = 1; }
 message SInt32Const    { sint32 val = 1 [(validate.rules).sint32.const = 1]; }
@@ -100,7 +100,7 @@ message SInt32GTLT     { sint32 val = 1 [(validate.rules).sint32 = {gt: 0, lt: 1
 message SInt32ExLTGT   { sint32 val = 1 [(validate.rules).sint32 = {lt: 0, gt: 10}]; }
 message SInt32GTELTE   { sint32 val = 1 [(validate.rules).sint32 = {gte: 128, lte: 256}]; }
 message SInt32ExGTELTE { sint32 val = 1 [(validate.rules).sint32 = {lte: 128, gte: 256}]; }
-message SInt32Ignore   { sint32 val = 1 [(validate.rules).sint32 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message SInt32Ignore   { sint32 val = 1 [(validate.rules).sint32 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message SInt64None     { sint64 val = 1; }
 message SInt64Const    { sint64 val = 1 [(validate.rules).sint64.const = 1]; }
@@ -114,7 +114,7 @@ message SInt64GTLT     { sint64 val = 1 [(validate.rules).sint64 = {gt: 0, lt: 1
 message SInt64ExLTGT   { sint64 val = 1 [(validate.rules).sint64 = {lt: 0, gt: 10}]; }
 message SInt64GTELTE   { sint64 val = 1 [(validate.rules).sint64 = {gte: 128, lte: 256}]; }
 message SInt64ExGTELTE { sint64 val = 1 [(validate.rules).sint64 = {lte: 128, gte: 256}]; }
-message SInt64Ignore   { sint64 val = 1 [(validate.rules).sint64 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message SInt64Ignore   { sint64 val = 1 [(validate.rules).sint64 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message Fixed32None     { fixed32 val = 1; }
 message Fixed32Const    { fixed32 val = 1 [(validate.rules).fixed32.const = 1]; }
@@ -128,7 +128,7 @@ message Fixed32GTLT     { fixed32 val = 1 [(validate.rules).fixed32 = {gt: 5, lt
 message Fixed32ExLTGT   { fixed32 val = 1 [(validate.rules).fixed32 = {lt: 5, gt: 10}]; }
 message Fixed32GTELTE   { fixed32 val = 1 [(validate.rules).fixed32 = {gte: 128, lte: 256}]; }
 message Fixed32ExGTELTE { fixed32 val = 1 [(validate.rules).fixed32 = {lte: 128, gte: 256}]; }
-message Fixed32Ignore   { fixed32 val = 1 [(validate.rules).fixed32 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message Fixed32Ignore   { fixed32 val = 1 [(validate.rules).fixed32 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message Fixed64None     { fixed64 val = 1; }
 message Fixed64Const    { fixed64 val = 1 [(validate.rules).fixed64.const = 1]; }
@@ -142,7 +142,7 @@ message Fixed64GTLT     { fixed64 val = 1 [(validate.rules).fixed64 = {gt: 5, lt
 message Fixed64ExLTGT   { fixed64 val = 1 [(validate.rules).fixed64 = {lt: 5, gt: 10}]; }
 message Fixed64GTELTE   { fixed64 val = 1 [(validate.rules).fixed64 = {gte: 128, lte: 256}]; }
 message Fixed64ExGTELTE { fixed64 val = 1 [(validate.rules).fixed64 = {lte: 128, gte: 256}]; }
-message Fixed64Ignore   { fixed64 val = 1 [(validate.rules).fixed64 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message Fixed64Ignore   { fixed64 val = 1 [(validate.rules).fixed64 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message SFixed32None     { sfixed32 val = 1; }
 message SFixed32Const    { sfixed32 val = 1 [(validate.rules).sfixed32.const = 1]; }
@@ -156,7 +156,7 @@ message SFixed32GTLT     { sfixed32 val = 1 [(validate.rules).sfixed32 = {gt: 0,
 message SFixed32ExLTGT   { sfixed32 val = 1 [(validate.rules).sfixed32 = {lt: 0, gt: 10}]; }
 message SFixed32GTELTE   { sfixed32 val = 1 [(validate.rules).sfixed32 = {gte: 128, lte: 256}]; }
 message SFixed32ExGTELTE { sfixed32 val = 1 [(validate.rules).sfixed32 = {lte: 128, gte: 256}]; }
-message SFixed32Ignore   { sfixed32 val = 1 [(validate.rules).sfixed32 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message SFixed32Ignore   { sfixed32 val = 1 [(validate.rules).sfixed32 = {gte: 128, lte: 256, ignore_empty: true}]; }
 
 message SFixed64None     { sfixed64 val = 1; }
 message SFixed64Const    { sfixed64 val = 1 [(validate.rules).sfixed64.const = 1]; }
@@ -170,4 +170,4 @@ message SFixed64GTLT     { sfixed64 val = 1 [(validate.rules).sfixed64 = {gt: 0,
 message SFixed64ExLTGT   { sfixed64 val = 1 [(validate.rules).sfixed64 = {lt: 0, gt: 10}]; }
 message SFixed64GTELTE   { sfixed64 val = 1 [(validate.rules).sfixed64 = {gte: 128, lte: 256}]; }
 message SFixed64ExGTELTE { sfixed64 val = 1 [(validate.rules).sfixed64 = {lte: 128, gte: 256}]; }
-message SFixed64Ignore   { sfixed64 val = 1 [(validate.rules).sfixed64 = {lte: 128, gte: 256, ignore_empty: true}]; }
+message SFixed64Ignore   { sfixed64 val = 1 [(validate.rules).sfixed64 = {gte: 128, lte: 256, ignore_empty: true}]; }


### PR DESCRIPTION
Prior to this change, ignore_empty test cases where testing an negated
range (<=128, >=256), and since the value 0 falls in that range, the
tests would pass regardless of ignore_empty.  To make the tests pass
for the right reason (ignore_empty is given), the range is changed to
[128,256] so 0 falls outside the range.

The tests for Float already had the correct range. This commit updates
all the other messages to be consistent with Float.