### PR TITLE
Make iteration order for Go maps consistent

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -13,6 +13,7 @@ import (
 	"net/mail"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -37,6 +38,7 @@ var (
 	_ = (*url.URL)(nil)
 	_ = (*mail.Address)(nil)
 	_ = anypb.Any{}
+	_ = sort.Sort
 
 	{{ range (externalEnums .) }}
 		_ = {{ pkg . }}.{{ name . }}(0)

--- a/templates/goshared/map.go
+++ b/templates/goshared/map.go
@@ -36,7 +36,16 @@ const mapTpl = `
 	{{ end }}
 
 	{{ if or $r.GetNoSparse (ne (.Elem "" "").Typ "none") (ne (.Key "" "").Typ "none") }}
-		for key, val := range {{ accessor . }} {
+		{{- /* Sort the keys to make the iteration order (and therefore failure output) deterministic. */ -}}
+		sorted_keys := make([]{{ (typ .Field).Key }}, len({{ accessor . }}))
+		i := 0
+		for key := range {{ accessor . }} {
+			sorted_keys[i] = key
+			i++
+		}
+		sort.Slice(sorted_keys, func (i, j int) bool { return sorted_keys[i] < sorted_keys[j] })
+		for _, key := range sorted_keys {
+			val := {{ accessor .}}[key]
 			_ = val
 
 			{{ if $r.GetNoSparse }}

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -21,7 +21,6 @@ func Register(tpl *template.Template, params pgs.Parameters) {
 	tpl.Funcs(map[string]interface{}{
 		"accessor":      fns.accessor,
 		"byteStr":       fns.byteStr,
-		"snakeCase":	 fns.snakeCase,
 		"cmt":           pgs.C80,
 		"durGt":         fns.durGt,
 		"durLit":        fns.durLit,
@@ -41,6 +40,7 @@ func Register(tpl *template.Template, params pgs.Parameters) {
 		"name":          fns.Name,
 		"oneof":         fns.oneofTypeName,
 		"pkg":           fns.PackageName,
+		"snakeCase":     fns.snakeCase,
 		"tsGt":          fns.tsGt,
 		"tsLit":         fns.tsLit,
 		"tsStr":         fns.tsStr,


### PR DESCRIPTION
Sort the keys before iteration to make the iteration order
deterministic. This fixes a test flake where the first error returned by
ValidateAll() didn't match the error returned by Validate(). Since the
iteration order was unspecified, ValidateAll() would sometimes return
the same set of errors in different orders.

Signed-off-by: Alex Konradi <akonradi@google.com>