### PR TITLE
Fix enum import in repeated field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ __pycache__/
 /tests/harness/cases/gogo
 /tests/harness/cases/other_package/go
 /tests/harness/cases/other_package/gogo
+/tests/harness/cases/yet_another_package/go
+/tests/harness/cases/yet_another_package/gogo
 /tests/harness/go/harness.pb.go
 /tests/harness/go/main/go-harness
 /tests/harness/go/main/go-harness.exe

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ testcases: bin/protoc-gen-go ## generate the test harness case protos
 	mkdir tests/harness/cases/go
 	rm -r tests/harness/cases/other_package/go || true
 	mkdir tests/harness/cases/other_package/go
+	rm -r tests/harness/cases/yet_another_package/go || true
+	mkdir tests/harness/cases/yet_another_package/go
 	# protoc-gen-go makes us go a package at a time
 	cd tests/harness/cases/other_package && \
 	protoc \
@@ -85,13 +87,21 @@ testcases: bin/protoc-gen-go ## generate the test harness case protos
 		--plugin=protoc-gen-go=${GOPATH}/bin/protoc-gen-go \
 		--validate_out="module=${PACKAGE}/tests/harness/cases/other_package/go,lang=go:./go" \
 		./*.proto
+	cd tests/harness/cases/yet_another_package && \
+	protoc \
+		-I . \
+		-I ../../../.. \
+		--go_out="module=${PACKAGE}/tests/harness/cases/yet_another_package/go,${GO_IMPORT}:./go" \
+		--plugin=protoc-gen-go=${GOPATH}/bin/protoc-gen-go \
+		--validate_out="module=${PACKAGE}/tests/harness/cases/yet_another_package/go,lang=go:./go" \
+		./*.proto
 	cd tests/harness/cases && \
 	protoc \
 		-I . \
 		-I ../../.. \
-		--go_out="module=${PACKAGE}/tests/harness/cases/go,Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/go,${GO_IMPORT}:./go" \
+		--go_out="module=${PACKAGE}/tests/harness/cases/go,Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/go;other_package,Mtests/harness/cases/yet_another_package/embed.proto=${PACKAGE}/tests/harness/cases/yet_another_package/go,${GO_IMPORT}:./go" \
 		--plugin=protoc-gen-go=${GOPATH}/bin/protoc-gen-go \
-		--validate_out="module=${PACKAGE}/tests/harness/cases/go,lang=go,Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/go:./go" \
+		--validate_out="module=${PACKAGE}/tests/harness/cases/go,lang=go,Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/go,Mtests/harness/cases/yet_another_package/embed.proto=${PACKAGE}/tests/harness/cases/yet_another_package/go:./go" \
 		./*.proto
 
 validate/validate.pb.go: bin/protoc-gen-go validate/validate.proto
@@ -103,7 +113,7 @@ validate/validate.pb.go: bin/protoc-gen-go validate/validate.proto
 tests/harness/go/harness.pb.go: bin/protoc-gen-go tests/harness/harness.proto
 	# generates the test harness protos
 	cd tests/harness && protoc -I . \
-		--plugin=protoc-gen-go=$protoc-gen-go \
+		--plugin=protoc-gen-go=${GOPATH}/bin/protoc-gen-go \
 		--go_out="module=${PACKAGE}/tests/harness/go,${GO_IMPORT}:./go" harness.proto
 
 tests/harness/go/main/go-harness:
@@ -162,7 +172,8 @@ clean: ## clean up generated files
 		tests/harness/go/harness.pb.go
 	rm -rf \
 		tests/harness/cases/go \
-		tests/harness/cases/other_package/go
+		tests/harness/cases/other_package/go \
+		tests/harness/cases/yet_another_package/go
 	rm -rf \
 		python/dist \
 		python/*.egg-info

--- a/java/pgv-java-validation/pom.xml
+++ b/java/pgv-java-validation/pom.xml
@@ -65,6 +65,7 @@
                                 <include>tests/harness/harness.proto</include>
                                 <include>tests/harness/cases/*.proto</include>
                                 <include>tests/harness/cases/other_package/*.proto</include>
+                                <include>tests/harness/cases/yet_another_package/*.proto</include>
                             </includes>
                         </configuration>
                     </execution>
@@ -79,6 +80,7 @@
                             <includes>
                                 <include>tests/harness/cases/*.proto</include>
                                 <include>tests/harness/cases/other_package/*.proto</include>
+                                <include>tests/harness/cases/yet_another_package/*.proto</include>
                             </includes>
                             <pluginId>java-pgv</pluginId>
                             <pluginArtifact>io.envoyproxy.protoc-gen-validate:protoc-gen-validate:${project.version}:exe:${os.detected.classifier}</pluginArtifact>

--- a/java/pgv-java-validation/src/main/java/io/envoyproxy/pgv/validation/BUILD
+++ b/java/pgv-java-validation/src/main/java/io/envoyproxy/pgv/validation/BUILD
@@ -12,6 +12,8 @@ java_library(
         "//tests/harness/cases:java",
         "//tests/harness/cases/other_package:embed_java_proto",
         "//tests/harness/cases/other_package:java",
+        "//tests/harness/cases/yet_another_package:embed_java_proto",
+        "//tests/harness/cases/yet_another_package:java",
         "//validate:validate_java",
         "@com_google_guava//jar",
         "@com_google_protobuf//:protobuf_java",

--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -40,8 +40,8 @@ var (
 	_ = anypb.Any{}
 	_ = sort.Sort
 
-	{{ range (externalEnums .) }}
-		_ = {{ pkg . }}.{{ name . }}(0)
+	{{ range $pkg, $path := enumPackages (externalEnums .) }}
+		_ = {{ $pkg }}.{{ (index (externalEnums $) 0).Parent.Name }}_{{ (index (externalEnums $) 0).Name }}(0)
 	{{ end }}
 )
 

--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -20,7 +20,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/anypb"
 
-	{{ range $path, $pkg := enumPackages (externalEnums .) }}
+	{{ range $pkg, $path := enumPackages (externalEnums .) }}
 		{{ $pkg }} "{{ $path }}"
 	{{ end }}
 )

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -3,6 +3,7 @@ package goshared
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -325,11 +326,23 @@ func (fns goSharedFuncs) externalEnums(file pgs.File) []pgs.Enum {
 	return out
 }
 
-func (fns goSharedFuncs) enumPackages(enums []pgs.Enum) map[pgs.FilePath]pgs.Name {
-	out := make(map[pgs.FilePath]pgs.Name, len(enums))
+func (fns goSharedFuncs) enumPackages(enums []pgs.Enum) map[pgs.Name]pgs.FilePath {
+	out := make(map[pgs.Name]pgs.FilePath, len(enums))
+
+	nameCollision := make(map[pgs.Name]int)
 
 	for _, en := range enums {
-		out[fns.ImportPath(en)] = fns.PackageName(en)
+
+		pkgName := fns.PackageName(en)
+
+		path, ok := out[pkgName]
+
+		if ok && path != fns.ImportPath(en) {
+			nameCollision[pkgName] = nameCollision[pkgName] + 1
+			pkgName = pkgName + pgs.Name(strconv.Itoa(nameCollision[pkgName]))
+		}
+
+		out[pkgName] = fns.ImportPath(en)
 	}
 
 	return out

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -11,8 +11,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/envoyproxy/protoc-gen-validate/templates/shared"
-	"github.com/lyft/protoc-gen-star"
-	"github.com/lyft/protoc-gen-star/lang/go"
+	pgs "github.com/lyft/protoc-gen-star"
+	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
 )
 
 func Register(tpl *template.Template, params pgs.Parameters) {
@@ -306,7 +306,17 @@ func (fns goSharedFuncs) externalEnums(file pgs.File) []pgs.Enum {
 
 	for _, msg := range file.AllMessages() {
 		for _, fld := range msg.Fields() {
-			if en := fld.Type().Enum(); fld.Type().IsEnum() && en.Package().ProtoName() != fld.Package().ProtoName() && fns.PackageName(en) != fns.PackageName(fld) {
+			var en pgs.Enum
+
+			if fld.Type().IsEnum() {
+				en = fld.Type().Enum()
+			}
+
+			if fld.Type().IsRepeated() {
+				en = fld.Type().Element().Enum()
+			}
+
+			if en != nil && en.Package().ProtoName() != fld.Package().ProtoName() && fns.PackageName(en) != fns.PackageName(fld) {
 				out = append(out, en)
 			}
 		}

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -34,6 +34,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tests/harness/cases/other_package:embed_proto",
+        "//tests/harness/cases/yet_another_package:embed_proto",
         "//validate:validate_proto",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:duration_proto",
@@ -48,6 +49,7 @@ pgv_go_proto_library(
     proto = ":cases_proto",
     deps = [
         "//tests/harness/cases/other_package:go",
+        "//tests/harness/cases/yet_another_package:go",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
@@ -59,6 +61,7 @@ pgv_cc_proto_library(
     name = "cc",
     cc_deps = [
         "//tests/harness/cases/other_package:cc",
+        "//tests/harness/cases/yet_another_package:cc",
     ],
     visibility = ["//tests:__subpackages__"],
     deps = [":cases_proto"],
@@ -75,6 +78,7 @@ pgv_java_proto_library(
     java_deps = [
         ":cases_java_proto",
         "//tests/harness/cases/other_package:java",
+        "//tests/harness/cases/yet_another_package:java",
     ],
     visibility = ["//visibility:public"],
     deps = [":cases_proto"],
@@ -106,6 +110,7 @@ py_proto_library(
     deps = [
         "//validate:validate_py",
         "//tests/harness/cases/other_package:embed_python_proto",
+        "//tests/harness/cases/yet_another_package:embed_python_proto",
         "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/tests/harness/cases/enums.proto
+++ b/tests/harness/cases/enums.proto
@@ -4,6 +4,7 @@ package tests.harness.cases;
 option go_package = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go;cases";
 import "validate/validate.proto";
 import "tests/harness/cases/other_package/embed.proto";
+import "tests/harness/cases/yet_another_package/embed.proto";
 
 enum TestEnum {
     ZERO = 0;
@@ -41,6 +42,7 @@ message EnumExternal { other_package.Embed.Enumerated val = 1 [(validate.rules).
 
 message RepeatedEnumDefined { repeated TestEnum val = 1 [(validate.rules).repeated.items.enum.defined_only = true]; }
 message RepeatedExternalEnumDefined { repeated other_package.Embed.Enumerated val = 1 [(validate.rules).repeated.items.enum.defined_only = true]; }
+message RepeatedYetAnotherExternalEnumDefined { repeated yet_another_package.Embed.Enumerated val = 1 [(validate.rules).repeated.items.enum.defined_only = true]; }
 
 message MapEnumDefined { map<string, TestEnum> val = 1 [(validate.rules).map.values.enum.defined_only = true]; }
 message MapExternalEnumDefined { map<string, other_package.Embed.Enumerated> val = 1 [(validate.rules).map.values.enum.defined_only = true]; }

--- a/tests/harness/cases/yet_another_package/BUILD
+++ b/tests/harness/cases/yet_another_package/BUILD
@@ -1,0 +1,80 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load(
+    "//bazel:pgv_proto_library.bzl",
+    "pgv_cc_proto_library",
+    "pgv_go_proto_library",
+    "pgv_java_proto_library",
+)
+
+proto_library(
+    name = "embed_proto",
+    srcs = [
+        "embed.proto",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["//validate:validate_proto"],
+)
+
+pgv_go_proto_library(
+    name = "go",
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go",
+    proto = ":embed_proto",
+    deps = [
+        "@org_golang_google_protobuf//types/known/anypb:go_default_library",
+    ],
+)
+
+pgv_cc_proto_library(
+    name = "cc",
+    visibility = ["//tests:__subpackages__"],
+    deps = [":embed_proto"],
+)
+
+proto_library(
+    name = "yet_another_package_proto",
+    srcs = ["embed.proto"],
+    visibility = ["//visibility:public"],
+    deps = ["//validate:validate_proto"],
+)
+
+go_proto_library(
+    name = "yet_another_package_go_proto",
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package",
+    proto = ":yet_another_package_proto",
+    visibility = ["//visibility:public"],
+    deps = ["//validate:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    embed = [":yet_another_package_go_proto"],
+    importpath = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package",
+    visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "embed_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":embed_proto"],
+)
+
+pgv_java_proto_library(
+    name = "java",
+    java_deps = [":embed_java_proto"],
+    visibility = ["//visibility:public"],
+    deps = [":embed_proto"],
+)
+
+py_proto_library(
+    name = "embed_python_proto",
+    srcs = ["embed.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//validate:validate_py",
+        "@com_google_protobuf//:protobuf_python",
+    ],
+)

--- a/tests/harness/cases/yet_another_package/embed.proto
+++ b/tests/harness/cases/yet_another_package/embed.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package tests.harness.cases.yet_another_package;
+option go_package = "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go;yet_another_package";
+
+import "validate/validate.proto";
+
+// Validate message embedding across packages.
+message Embed {
+    int64 val = 1 [(validate.rules).int64.gt = 0];
+
+    enum Enumerated { VALUE = 0; }
+}

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//tests/harness:harness_go_proto",
         "//tests/harness/cases:go",
         "//tests/harness/cases/other_package:go",
+        "//tests/harness/cases/yet_another_package:go",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/durationpb:go_default_library",

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -6,6 +6,7 @@ import (
 
 	cases "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
 	other_package "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"
+	yet_another_package "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -1022,6 +1023,8 @@ var enumCases = []TestCase{
 
 	{"enum repeated (external) - defined_only - valid", &cases.RepeatedExternalEnumDefined{Val: []other_package.Embed_Enumerated{other_package.Embed_VALUE}}, 0},
 	{"enum repeated (external) - defined_only - invalid", &cases.RepeatedExternalEnumDefined{Val: []other_package.Embed_Enumerated{math.MaxInt32}}, 1},
+
+	{"enum repeated (another external) - defined_only - valid", &cases.RepeatedYetAnotherExternalEnumDefined{Val: []yet_another_package.Embed_Enumerated{yet_another_package.Embed_VALUE}}, 0},
 
 	{"enum map - defined_only - valid", &cases.MapEnumDefined{Val: map[string]cases.TestEnum{"foo": cases.TestEnum_TWO}}, 0},
 	{"enum map - defined_only - invalid", &cases.MapEnumDefined{Val: map[string]cases.TestEnum{"foo": math.MaxInt32}}, 1},

--- a/tests/harness/go/main/BUILD
+++ b/tests/harness/go/main/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//tests/harness:harness_go_proto",
         "//tests/harness/cases:go",
         "//tests/harness/cases/other_package:go",
+        "//tests/harness/cases/yet_another_package:go",
         "@org_golang_google_protobuf//proto:go_default_library",
         "@org_golang_google_protobuf//types/known/anypb:go_default_library",
         "@org_golang_google_protobuf//types/known/durationpb:go_default_library",

--- a/tests/harness/go/main/harness.go
+++ b/tests/harness/go/main/harness.go
@@ -9,6 +9,7 @@ import (
 	"github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
 	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
 	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"
+	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
 	"github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
 	"google.golang.org/protobuf/proto"
 )


### PR DESCRIPTION
I am trying to fix https://github.com/envoyproxy/protoc-gen-validate/issues/511

Following the fix I noticed another bug in the go import statement generation for enums, go package names overlap. I tried to fix it but I am not sure to understand how harness works.

When executing the make task `testcases`, I am able to generate fixed pb files. Imports look like this:

```
	_go "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"

	_go1 "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
```

But when I am running `harness`, generated files are still broken, imports are not name correctly:

```
	_go "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"

	_go "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
```

Notice the overlapping import names.

I will keep on trying, but do you have any tips on this ?
