### PR TITLE
doc: correct comment describing string.len_bytes

### DIFF
--- a/validate/validate.proto
+++ b/validate/validate.proto
@@ -524,7 +524,6 @@ message StringRules {
     optional uint64 max_len = 3;
 
     // LenBytes specifies that this field must be the specified number of bytes
-    // at a minimum
     optional uint64 len_bytes = 20;
 
     // MinBytes specifies that this field must be the specified number of bytes


### PR DESCRIPTION
It looks like `len_bytes` is like `len` which is an exact match, not a minimum match.