### PR TITLE
Upgrade java protobuf, protoc, and grpc deps for 'optional' support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ following to your pom.xml or build.gradle.
         <plugin>
             <groupId>org.xolstice.maven.plugins</groupId>
             <artifactId>protobuf-maven-plugin</artifactId>
-            <version>0.5.0</version>
+            <version>0.6.1</version>
             <configuration>
                 <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
             </configuration>
@@ -162,18 +162,18 @@ following to your pom.xml or build.gradle.
 ```gradle
 plugins {
     ...
-    id "com.google.protobuf" version "0.8.6"
+    id "com.google.protobuf" version "${protobuf.version}"
     ...
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.5.1"
+        artifact = "com.google.protobuf:protoc:${protoc.version}"
     }
 
     plugins {
         javapgv {
-            artifact = "io.envoyproxy.protoc-gen-validate:protoc-gen-validate:0.1.0"
+            artifact = "io.envoyproxy.protoc-gen-validate:protoc-gen-validate:${pgv.version}"
         }
     }
 

--- a/java/pgv-java-grpc/pom.xml
+++ b/java/pgv-java-grpc/pom.xml
@@ -10,6 +10,18 @@
     <artifactId>pgv-java-grpc</artifactId>
     <name>PGV-Java gRPC Interceptors</name>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.google.api.grpc</groupId>
@@ -19,23 +31,19 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-core</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
-            <version>${grpc.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -72,7 +80,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.0</version>
+                <version>${protobuf.maven.plugin.version}</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>

--- a/java/pgv-java-stub/pom.xml
+++ b/java/pgv-java-stub/pom.xml
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.0</version>
+                <version>${protobuf.maven.plugin.version}</version>
                 <configuration>
                     <!--
                      ~ Embed generated validate.proto classes for all Protobuf 3.x versions. This is safe because

--- a/java/pgv-java-validation/pom.xml
+++ b/java/pgv-java-validation/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.0</version>
+                <version>${protobuf.maven.plugin.version}</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -42,15 +42,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <protoc.version>3.5.1</protoc.version>
+        <protoc.version>3.19.1</protoc.version>
+        <google.protobuf.version>3.19.1</google.protobuf.version>
+        <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
+
         <re2j.version>1.5</re2j.version>
         <commons.validator.version>1.7</commons.validator.version>
-        <google.protobuf.version>3.15.6</google.protobuf.version>
-        <grpc.version>1.36.1</grpc.version>
+        <grpc.version>1.42.1</grpc.version>
         <junit.version>4.12</junit.version>
         <assertj.version>3.11.1</assertj.version>
         <java.version>1.8</java.version>
-        <proto-google-common-protos.version>2.0.1</proto-google-common-protos.version>
+        <proto-google-common-protos.version>2.7.0</proto-google-common-protos.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Optional field support requires updating the protobuf and grpc java dependencies.

protobuf-maven-plugin -> 0.6.1
protobuf -> 3.19.1
protoc -> 3.19.1
grpc -> 1.42.1
