### PR TITLE
Fix enum import where not nested

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -20,8 +20,8 @@ import (
 
 	"google.golang.org/protobuf/types/known/anypb"
 
-	{{ range $pkg, $path := enumPackages (externalEnums .) }}
-		{{ $pkg }} "{{ $path }}"
+	{{ range enumPackages (externalEnums .) }}
+		{{ .Package }} "{{ .FilePath }}"
 	{{ end }}
 )
 
@@ -40,8 +40,12 @@ var (
 	_ = anypb.Any{}
 	_ = sort.Sort
 
-	{{ range $pkg, $path := enumPackages (externalEnums .) }}
-		_ = {{ $pkg }}.{{ (index (externalEnums $) 0).Parent.Name }}_{{ (index (externalEnums $) 0).Name }}(0)
+	{{ range enumPackages (externalEnums .) }}
+		{{ if eq .FirstEnum.Parent.Name .FirstEnum.File.Name }}
+		_ = {{ .Package }}.{{ .FirstEnum.Name }}(0)
+		{{ else }}
+		_ = {{ .Package }}.{{ .FirstEnum.Parent.Name }}_{{ .FirstEnum.Name }}(0)
+		{{ end }}
 	{{ end }}
 )
 


### PR DESCRIPTION
A fix for issue #552 

The solution in https://github.com/saltosystems/protoc-gen-validate/commit/267ccc1b0332bf7b8339c149d8ec38078c50b07b reverts back to an older version of the code, which then will not work with nested enums.

This should ideally work with both, but ... probably not a triple nested one.

Works in current master:
```proto
message foo {
  enum bar {
  }
}
```

Fails in current master:
```proto
enum bar {
}
```
as 'Parent' is the package/file