### PR TITLE
Java: Support for osx-aarch_64 architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     environment:
       MAVEN_OPTS: -Xms512m -Xmx1024m # Customize the JVM maximum heap limit
       GO111MODULE: "on"
-      CI_GO_VERSION: 1.14.7
+      CI_GO_VERSION: 1.17.6
     steps:
       - checkout:
           path: ~/.go_workspace/src/github.com/envoyproxy/protoc-gen-validate

--- a/java/pgv-artifacts/pom.xml
+++ b/java/pgv-artifacts/pom.xml
@@ -40,6 +40,26 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>osx-aarch_64</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <executable>go</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-o</argument>
+                                <argument>${project.build.directory}/protoc-gen-validate-${project.version}-osx-aarch_64.exe</argument>
+                                <argument>../..</argument>
+                            </arguments>
+                            <environmentVariables>
+                                <GOOS>darwin</GOOS>
+                                <GOARCH>arm64</GOARCH>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>linux_x86_32</id>
                         <goals>
                             <goal>exec</goal>
@@ -138,6 +158,21 @@
                                     <file>${project.build.directory}/protoc-gen-validate-${project.version}-osx-x86_64.exe</file>
                                     <type>exe</type>
                                     <classifier>osx-x86_64</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>osx-aarch_64</id>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/protoc-gen-validate-${project.version}-osx-aarch_64.exe</file>
+                                    <type>exe</type>
+                                    <classifier>osx-aarch_64</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>

--- a/java/pgv-java-stub/pom.xml
+++ b/java/pgv-java-stub/pom.xml
@@ -76,7 +76,7 @@
                      ~ Protobuf guarantees API stability for all 3.x version.
                      ~ https://github.com/protocolbuffers/protobuf/blob/17cc42a45aeab0f78a137fa6be6c36095db32e58/CHANGES.txt#L107-L122
                     -->
-                    <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -42,8 +42,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <protoc.version>3.19.1</protoc.version>
-        <google.protobuf.version>3.19.1</google.protobuf.version>
+        <protoc.version>3.19.4</protoc.version>
+        <google.protobuf.version>3.19.4</google.protobuf.version>
         <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
 
         <re2j.version>1.5</re2j.version>


### PR DESCRIPTION
Update the build system to generate artifacts for MacOS on ARM64
to support Apple Silicon / M1 machines.
