### PR TITLE
Fix go uuidPattern variable

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -47,7 +47,7 @@ var (
 
 {{- if fileneeds . "uuid" }}
 // define the regex for a UUID once up-front
-var _{{ snakeCase .File.InputPath.BaseName }}_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+var _{{ goValidSnakeCase .File.InputPath.BaseName }}_uuidPattern = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 {{ end }}
 
 {{ range .AllMessages }}

--- a/templates/goshared/known.go
+++ b/templates/goshared/known.go
@@ -56,7 +56,7 @@ const emailTpl = `
 
 const uuidTpl = `
 	func (m {{ (msgTyp .).Pointer }}) _validateUuid(uuid string) error {
-		if matched := _{{ snakeCase .File.InputPath.BaseName }}_uuidPattern.MatchString(uuid); !matched {
+		if matched := _{{ goValidSnakeCase .File.InputPath.BaseName }}_uuidPattern.MatchString(uuid); !matched {
 			return errors.New("invalid uuid format")
 		}
 

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -3,6 +3,7 @@ package goshared
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -20,35 +21,36 @@ func Register(tpl *template.Template, params pgs.Parameters) {
 	fns := goSharedFuncs{pgsgo.InitContext(params)}
 
 	tpl.Funcs(map[string]interface{}{
-		"accessor":      fns.accessor,
-		"byteStr":       fns.byteStr,
-		"cmt":           pgs.C80,
-		"durGt":         fns.durGt,
-		"durLit":        fns.durLit,
-		"durStr":        fns.durStr,
-		"err":           fns.err,
-		"errCause":      fns.errCause,
-		"errIdx":        fns.errIdx,
-		"errIdxCause":   fns.errIdxCause,
-		"errname":       fns.errName,
-		"multierrname":  fns.multiErrName,
-		"inKey":         fns.inKey,
-		"inType":        fns.inType,
-		"isBytes":       fns.isBytes,
-		"lit":           fns.lit,
-		"lookup":        fns.lookup,
-		"msgTyp":        fns.msgTyp,
-		"name":          fns.Name,
-		"oneof":         fns.oneofTypeName,
-		"pkg":           fns.PackageName,
-		"snakeCase":     fns.snakeCase,
-		"tsGt":          fns.tsGt,
-		"tsLit":         fns.tsLit,
-		"tsStr":         fns.tsStr,
-		"typ":           fns.Type,
-		"unwrap":        fns.unwrap,
-		"externalEnums": fns.externalEnums,
-		"enumPackages":  fns.enumPackages,
+		"accessor":         fns.accessor,
+		"byteStr":          fns.byteStr,
+		"cmt":              pgs.C80,
+		"durGt":            fns.durGt,
+		"durLit":           fns.durLit,
+		"durStr":           fns.durStr,
+		"err":              fns.err,
+		"errCause":         fns.errCause,
+		"errIdx":           fns.errIdx,
+		"errIdxCause":      fns.errIdxCause,
+		"errname":          fns.errName,
+		"multierrname":     fns.multiErrName,
+		"inKey":            fns.inKey,
+		"inType":           fns.inType,
+		"isBytes":          fns.isBytes,
+		"lit":              fns.lit,
+		"lookup":           fns.lookup,
+		"msgTyp":           fns.msgTyp,
+		"name":             fns.Name,
+		"oneof":            fns.oneofTypeName,
+		"pkg":              fns.PackageName,
+		"snakeCase":        fns.snakeCase,
+		"goValidSnakeCase": fns.goValidSnakeCase,
+		"tsGt":             fns.tsGt,
+		"tsLit":            fns.tsLit,
+		"tsStr":            fns.tsStr,
+		"typ":              fns.Type,
+		"unwrap":           fns.unwrap,
+		"externalEnums":    fns.externalEnums,
+		"enumPackages":     fns.enumPackages,
 	})
 
 	template.Must(tpl.New("msg").Parse(msgTpl))
@@ -349,5 +351,12 @@ func (fns goSharedFuncs) enumPackages(enums []pgs.Enum) map[pgs.Name]pgs.FilePat
 }
 
 func (fns goSharedFuncs) snakeCase(name string) string {
+	return strcase.ToSnake(name)
+}
+
+// goValidSnakeCase covert string to go valid snake case by replace all special character to underline
+func (fns goSharedFuncs) goValidSnakeCase(name string) string {
+	regex := regexp.MustCompile(`\W`)
+	name = regex.ReplaceAllString(name, "_")
 	return strcase.ToSnake(name)
 }


### PR DESCRIPTION
A fix for issues #276 

when filename contain special character variable name of uuidPattern will not valid for go

