### PR TITLE
Various small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ gazelle: ## runs gazelle against the codebase to generate Bazel BUILD files
 
 .PHONY: lint
 lint: bin/golint bin/shadow ## lints the package for common code smells
-	test -z "$(gofmt -d -s ./*.go)" || (gofmt -d -s ./*.go && exit 1)
+	test -z "$(shell gofmt -d -s ./*.go)" || (gofmt -d -s ./*.go && exit 1)
 	# golint -set_exit_status
 	# check for variable shadowing
 	go vet -vettool=$(shell pwd)/bin/shadow ./...

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -318,7 +318,8 @@ func (fns CCFuncs) cType(t pgs.FieldType) string {
 		return fns.cTypeOfString(fns.Type(t.Field()).Element().String())
 	}
 
-	return fns.cTypeOfString(fns.Type(t.Field()).String())
+	// Use Value() to strip any potential pointer type.
+	return fns.cTypeOfString(fns.Type(t.Field()).Value().String())
 }
 
 func (fns CCFuncs) cTypeOfString(s string) string {

--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -41,7 +41,7 @@ var (
 	_ = sort.Sort
 
 	{{ range $pkg, $path := enumPackages (externalEnums .) }}
-		_ = {{ $pkg }}.{{ (index (externalEnums $) 0).Parent.Name }}_{{ (index (externalEnums $) 0).Name }}(0)
+	_ = {{ $pkg }}.{{ enumName (index (externalEnums $) 0) }}(0)
 	{{ end }}
 )
 

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -198,11 +198,6 @@ func (fns goSharedFuncs) isBytes(f interface {
 	return f.ProtoType() == pgs.BytesT
 }
 
-func (fns goSharedFuncs) isMessage(i interface{}) bool {
-	_, ok := i.(pgs.Message)
-	return ok
-}
-
 func (fns goSharedFuncs) byteStr(x []byte) string {
 	elms := make([]string, len(x))
 	for i, b := range x {
@@ -336,13 +331,13 @@ func (fns goSharedFuncs) externalEnums(file pgs.File) []pgs.Enum {
 func (fns goSharedFuncs) enumName(enum pgs.Enum) string {
 	out := string(enum.Name())
 	parent := enum.Parent()
-    for {
+	for {
 		message, ok := parent.(pgs.Message)
 		if ok {
-          out = string(message.Name()) + "_" + out
-		  parent = message.Parent()
+			out = string(message.Name()) + "_" + out
+			parent = message.Parent()
 		} else {
-          return out
+			return out
 		}
 	}
 }

--- a/tests/harness/cases/enums.proto
+++ b/tests/harness/cases/enums.proto
@@ -39,6 +39,7 @@ message EnumNotIn      { TestEnum val = 1 [(validate.rules).enum = { not_in: [1]
 message EnumAliasNotIn { TestEnumAlias val = 1 [(validate.rules).enum = { not_in: [1]}]; }
 
 message EnumExternal { other_package.Embed.Enumerated val = 1 [(validate.rules).enum.defined_only = true]; }
+message EnumExternal2 { other_package.Embed.DoubleEmbed.DoubleEnumerated val = 1 [(validate.rules).enum.defined_only = true]; }
 
 message RepeatedEnumDefined { repeated TestEnum val = 1 [(validate.rules).repeated.items.enum.defined_only = true]; }
 message RepeatedExternalEnumDefined { repeated other_package.Embed.Enumerated val = 1 [(validate.rules).repeated.items.enum.defined_only = true]; }

--- a/tests/harness/cases/other_package/embed.proto
+++ b/tests/harness/cases/other_package/embed.proto
@@ -7,6 +7,10 @@ import "validate/validate.proto";
 
 // Validate message embedding across packages.
 message Embed {
+    message DoubleEmbed {
+        enum DoubleEnumerated { VALUE = 0; }
+    }
+
     int64 val = 1 [(validate.rules).int64.gt = 0];
 
     enum Enumerated { VALUE = 0; }

--- a/tests/harness/cases/strings.proto
+++ b/tests/harness/cases/strings.proto
@@ -37,3 +37,9 @@ message StringHttpHeaderName { string val = 1 [(validate.rules).string.well_know
 message StringHttpHeaderValue     { string val = 1 [(validate.rules).string.well_known_regex = HTTP_HEADER_VALUE]; }
 message StringValidHeader    { string val = 1 [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE, strict: false}]; }
 message StringUUIDIgnore     { string val = 1 [(validate.rules).string = {uuid: true, ignore_empty: true}]; }
+
+message StringInOneOf {
+    oneof foo {
+      string bar = 1 [(validate.rules).string = {in: "a" in: "b"}];
+    }
+  }

--- a/tools.go
+++ b/tools.go
@@ -1,10 +1,11 @@
+//go:build tools
 // +build tools
 
 package main
 
 import (
-	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 	_ "golang.org/x/lint/golint"
-	_ "golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow"
 	_ "golang.org/x/net/context"
+	_ "golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -59,7 +59,8 @@ public:
 
   static bool CheckMessage(const T& m, ValidationMsg* err)
   {
-    auto val = static_cast<Validator<T>*>(validators()[std::type_index(typeid(T))]);
+    // Run typeid() on the variable vs. the type to allow polymorphic lookup of the validator.
+    auto val = static_cast<Validator<T>*>(validators()[std::type_index(typeid(m))]);
     if (val) {
       return val->check_(m, err);
     }


### PR DESCRIPTION
1) Fix regression from
   https://github.com/envoyproxy/protoc-gen-validate/pull/529. The
   code needs to handle enums at file scope and in a message. At the
   same time also handle arbitrary nesting.
2) Fix regression from https://github.com/envoyproxy/protoc-gen-validate/pull/537
   when dealing with single element string oneofs (and possibly other
   types being returned as pointer types vs. value types and breaking in
   queries. This fixes that for both C++ and Go. It's possible this fix
   shoudl be in PG* but doing it here for simplicity.
3) Modify the C++ validator registry to have polymorphic lookup
   capability which I want to use in Envoy.

Signed-off-by: Matt Klein <mklein@lyft.com>