### PR TITLE
enum: fix another regression inside of oneof

### DIFF
--- a/templates/goshared/enum.go
+++ b/templates/goshared/enum.go
@@ -6,7 +6,7 @@ const enumTpl = `
 		{{ template "in" . }}
 
 		{{ if $r.GetDefinedOnly }}
-			if _, ok := {{ (typ $f).Element }}_name[int32({{ accessor . }})]; !ok {
+			if _, ok := {{ (typ $f).Element.Value }}_name[int32({{ accessor . }})]; !ok {
 				err := {{ err . "value must be one of the defined enum values" }}
 				if !all { return err }
 				errors = append(errors, err)

--- a/tests/harness/cases/enums.proto
+++ b/tests/harness/cases/enums.proto
@@ -47,3 +47,9 @@ message RepeatedYetAnotherExternalEnumDefined { repeated yet_another_package.Emb
 
 message MapEnumDefined { map<string, TestEnum> val = 1 [(validate.rules).map.values.enum.defined_only = true]; }
 message MapExternalEnumDefined { map<string, other_package.Embed.Enumerated> val = 1 [(validate.rules).map.values.enum.defined_only = true]; }
+
+message EnumInsideOneOf {
+    oneof foo {
+        TestEnum val = 1 [(validate.rules).enum.defined_only = true];
+    }
+}


### PR DESCRIPTION
Need to use Value() to remove any pointer in the case of
an optionally present field.

Signed-off-by: Matt Klein <mklein@lyft.com>