### PR TITLE
Fix Bazel's golang protobuf library hash mismatch

### DIFF
--- a/dependencies.bzl
+++ b/dependencies.bzl
@@ -104,8 +104,8 @@ def go_third_party():
     go_repository(
         name = "org_golang_google_protobuf",
         importpath = "google.golang.org/protobuf",
-        sum = "h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=",
-        version = "v1.27.1",
+        sum = "h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=",
+        version = "v1.28.0",
     )
     go_repository(
         name = "org_golang_x_crypto",


### PR DESCRIPTION
Both in HEAD and `v0.6.7`, I saw the Bazel build complains about the hash for the Golang Protobuf library.

> ERROR: ...: @com_envoyproxy_protoc_gen_validate//:protoc-gen-validate_lib depends on @org_golang_google_protobuf//types/pluginpb:pluginpb in repository @org_golang_google_protobuf which failed to fetch. no such package '@org_golang_google_protobuf//types/pluginpb': failed to fetch org_golang_google_protobuf: fetch_repo: downloaded module with sum h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=; expected sum h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=

This issue originated from gRPC wants to build Envoy protos, which depends on `protoc-gen-validate`: https://github.com/grpc/grpc/pull/29219.

This PR bumped the Golang Protobuf library's version up and updated the hash.

@akonradi PTAL.