### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,14 @@ jobs:
           fi
 
   javabuild:
-    machine:
-      image: ubuntu-2004:202010-01
+    docker:
+      - image: cimg/openjdk:17.0.1
     working_directory: ~/.go_workspace/src/github.com/envoyproxy/protoc-gen-validate/java
     environment:
       MAVEN_OPTS: -Xms512m -Xmx1024m # Customize the JVM maximum heap limit
       GO111MODULE: "on"
       CI_GO_VERSION: 1.17.6
+      PATH: /usr/local/go/bin:/opt/apache-maven/bin:/usr/bin:/bin
     steps:
       - checkout:
           path: ~/.go_workspace/src/github.com/envoyproxy/protoc-gen-validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:202010-01
     working_directory: ~/pgv
     steps:
       - checkout
@@ -15,7 +15,7 @@ jobs:
 
   javabuild:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:202010-01
     working_directory: ~/.go_workspace/src/github.com/envoyproxy/protoc-gen-validate/java
     environment:
       MAVEN_OPTS: -Xms512m -Xmx1024m # Customize the JVM maximum heap limit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     working_directory: ~/pgv
     steps:
       - checkout
@@ -13,7 +14,8 @@ jobs:
           fi
 
   javabuild:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     working_directory: ~/.go_workspace/src/github.com/envoyproxy/protoc-gen-validate/java
     environment:
       MAVEN_OPTS: -Xms512m -Xmx1024m # Customize the JVM maximum heap limit

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -39,9 +39,9 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-            strip_prefix = "zlib-1.2.11",
-            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+            sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+            strip_prefix = "zlib-1.2.12",
+            urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
         )
 
     if not native.existing_rule("bazel_skylib"):


### PR DESCRIPTION
zlib 1.2.11 was pulled upstream, this bump should fix the 404

The VMs on CI were not being pinned, we got auto-updated and the newer version isn't compatible since it seems to have changed the java setup.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>