### PR TITLE
Fix indentation of python templates with ignore_empty fields inside oneof

### DIFF
--- a/python/protoc_gen_validate/validator.py
+++ b/python/protoc_gen_validate/validator.py
@@ -181,7 +181,7 @@ def string_template(option_value, name):
     str_templ = """
     {%- set s = o.string -%}
     {% set i = 0 %}
-    {%- if s['ignore_empty'] -%}
+    {%- if s['ignore_empty'] %}
     if {{ name }}:
     {% set i = 4 %}
     {%- endif -%}
@@ -326,7 +326,7 @@ def bool_template(option_value, name):
 def num_template(option_value, name, num):
     num_tmpl = """
     {% set i = 0 %}
-    {%- if num.HasField('ignore_empty') -%}
+    {%- if num.HasField('ignore_empty') %}
     if {{ name }}:
     {% set i = 4 %}
     {%- endif -%}
@@ -701,7 +701,7 @@ def any_template(option_value, name, repeated=False):
 def bytes_template(option_value, name):
     bytes_tmpl = """
     {% set i = 0 %}
-    {%- if b['ignore_empty'] -%}
+    {%- if b['ignore_empty'] %}
     if {{ name }}:
     {% set i = 4 %}
     {%- endif -%}

--- a/tests/harness/cases/oneofs.proto
+++ b/tests/harness/cases/oneofs.proto
@@ -33,3 +33,11 @@ message OneOfRequired {
         int32        under_and_1_number = 4;
     }
 }
+
+message OneOfIgnoreEmpty {
+    oneof o {
+        string       x = 1 [(validate.rules).string = {ignore_empty: true, min_len: 3, max_len: 5}];
+        bytes        y = 2 [(validate.rules).bytes = {ignore_empty: true, min_len: 3, max_len: 5}];
+        int32        z = 3 [(validate.rules).int32 = {lte: 128, gte: 256, ignore_empty: true}];
+    }
+}

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -1199,6 +1199,10 @@ var oneofCases = []TestCase{
 
 	{"oneof - required - valid", &cases.OneOfRequired{O: &cases.OneOfRequired_X{X: ""}}, 0},
 	{"oneof - require - invalid", &cases.OneOfRequired{}, 1},
+
+	{"oneof - ignore_empty - valid (X)", &cases.OneOfIgnoreEmpty{O: &cases.OneOfIgnoreEmpty_X{X: ""}}, 0},
+	{"oneof - ignore_empty - valid (Y)", &cases.OneOfIgnoreEmpty{O: &cases.OneOfIgnoreEmpty_Y{Y: []byte("")}}, 0},
+	{"oneof - ignore_empty - valid (Z)", &cases.OneOfIgnoreEmpty{O: &cases.OneOfIgnoreEmpty_Z{Z: 0}}, 0},
 }
 
 var wrapperCases = []TestCase{


### PR DESCRIPTION
When ignore_empty used by a field inside a oneof then the generated python code was invalid. This is fixed by removal of the whitespace removal in the template to ensure if clause goes onto newline with base indentation.

Signed-off-by: James Fish <jfish@pinterest.com>