### PR TITLE
docs: fix README.md mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Check the [constraint rule comparison matrix](rule_comparison.md) for language-s
 - **well-known formats**: these rules provide advanced constraints for common string patterns. These constraints will typically be more permissive and performant than equivalent regular expression patterns, while providing more explanatory failure descriptions.
 
   ```protobuf
-  // x must be a valid email address (via RFC 1034)
+  // x must be a valid email address (via RFC 5322)
   string x = 1 [(validate.rules).string.email = true];
 
   // x must be a valid address (IP or Hostname).


### PR DESCRIPTION
https://github.com/envoyproxy/protoc-gen-validate/blob/61feee29cf191d1e4e2687adb8a0d390db7c27d9/validate/validate.proto#L569-L571

Signed-off-by: mori yuta <59682979+utamori@users.noreply.github.com>