### PR TITLE
Golang multipackage enum fix

### DIFF
--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -40,8 +40,8 @@ var (
 	_ = anypb.Any{}
 	_ = sort.Sort
 
-	{{ range $pkg, $path := enumPackages (externalEnums .) }}
-	_ = {{ $pkg }}.{{ enumName (index (externalEnums $) 0) }}(0)
+	{{ range (externalEnums .) }}
+		_ = {{ pkg . }}.{{ name . }}(0)
 	{{ end }}
 )
 

--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -41,7 +41,7 @@ var (
 	_ = sort.Sort
 
 	{{ range (externalEnums .) }}
-		_ = {{ pkg . }}.{{ name . }}(0)
+	_ = {{ pkg . }}.{{ name . }}(0)
 	{{ end }}
 )
 


### PR DESCRIPTION
There was an issue when proto file imports multiple enums from multiple files.
Example situation:
```
common
├── common.proto
├── enum1
│   └── enum1.proto
└── enum2
    └── enum2.proto
```
`enum1/enum1`:
```proto
syntax = "proto3";
option go_package = "sample/common/enum1;enum1";
package common.enum1;
enum ENUM1 {
  ENUM1_VAL0 = 0;
  ENUM1_VAL1 = 1;
}
```
`enum2/enum2`:
```proto
syntax = "proto3";
option go_package = "sample/common/enum2;enum2";
package common.enum2;
enum ENUM2 {
  ENUM2_VAL0 = 0;
  ENUM2_VAL1 = 1;
}
```
`common.proto`:
```proto
syntax = "proto3";
option go_package = "sample/common;common";
import "common/enum1/enum1.proto";
import "common/enum2/enum2.proto";
package common;
message Msg {
  common.enum1.ENUM1 enum1 = 1;
  common.enum2.ENUM2 enum2 = 2;
}
```

And the generated `common.pb.validate.go`:
```go
....
	_ = enum1.ENUM1(0)

	_ = enum2.ENUM1(0)
....
```

So main problem is enum name would only point to the first name.
And the problem is caused by constant 0 index here: https://github.com/envoyproxy/protoc-gen-validate/blob/61feee29cf191d1e4e2687adb8a0d390db7c27d9/templates/go/file.go#L43-L45

And this was introduced in https://github.com/envoyproxy/protoc-gen-validate/pull/529
Import packages changes was correct, but the defining enums was not correct, reverting the change.