### PR TITLE
Simplify build trigger filter pattern

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -6,7 +6,7 @@ name: Maven Deploy
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+(-rc.[0-9]+)*'
+      - 'v*.*.*'
 
 jobs:
   deploy:


### PR DESCRIPTION
even though the regex `v[0-9]+.[0-9]+.[0-9]+(-rc.[0-9]+)*` is valid, github doesn't appear to be happy with it. Simplifying to `v*.*.*` is fine

Signed-off-by: Elliot Jackson <13633636+ElliotMJackson@users.noreply.github.com>