### PR TITLE
Retract accidentally published versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.28.1
 )
+
+retract (
+	[v0.6.9, v0.6.12] // Published accidentally
+)


### PR DESCRIPTION
Outlined in #655 

A number of versions were created inadvertently whilst attempting to resolve the maven relocation. This has negatively affected our golang community. 

Retracting based on modules [documentation](https://go.dev/ref/mod#go-mod-file-retract):
> consider a case where the author of module example.com/m publishes version v1.0.0 accidentally. To prevent users from upgrading to v1.0.0, the author can add two retract directives to go.mod, then tag v1.0.1 with the retractions.
> ```
> retract (
>     v1.0.0 // Published accidentally.
>     v1.0.1 // Contains retractions only.
> )
> ```
> When a user runs go get example.com/m@latest, the go command reads retractions from v1.0.1, which is now the highest version. Both v1.0.0 and v1.0.1 are retracted, so the go command will upgrade (or downgrade!) to the next highest version, perhaps v0.9.5.

Versions 0.6.9 through 0.6.12(to be created with this PR) will be retracted.

Signed-off-by: Elliot Jackson <13633636+ElliotMJackson@users.noreply.github.com>