### PR TITLE
Housekeeping: Improve Go formatting and import consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,18 @@ bin/shadow:
 bin/golint:
 	GOBIN=$(shell pwd)/bin go install golang.org/x/lint/golint
 
+bin/goimports:
+	go install golang.org/x/tools/cmd/goimports@latest
+
+bin/gofumpt:
+	go install mvdan.cc/gofumpt@latest
+
+imports: bin/goimports lint
+	goimports -w -l .
+
+fumpt: bin/gofumpt imports
+	gofumpt -w -l .
+
 bin/protoc-gen-go:
 	GOBIN=$(shell pwd)/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1
 

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/envoyproxy/protoc-gen-validate/module"
-	"github.com/lyft/protoc-gen-star"
-	"github.com/lyft/protoc-gen-star/lang/go"
+	pgs "github.com/lyft/protoc-gen-star"
+	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 

--- a/module/checker.go
+++ b/module/checker.go
@@ -7,16 +7,18 @@ import (
 	"unicode/utf8"
 
 	"github.com/envoyproxy/protoc-gen-validate/validate"
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var unknown = ""
-var httpHeaderName = "^:?[0-9a-zA-Z!#$%&'*+-.^_|~\x60]+$"
-var httpHeaderValue = "^[^\u0000-\u0008\u000A-\u001F\u007F]*$"
-var headerString = "^[^\u0000\u000A\u000D]*$" // For non-strict validation.
+var (
+	unknown         = ""
+	httpHeaderName  = "^:?[0-9a-zA-Z!#$%&'*+-.^_|~\x60]+$"
+	httpHeaderValue = "^[^\u0000-\u0008\u000A-\u001F\u007F]*$"
+	headerString    = "^[^\u0000\u000A\u000D]*$" // For non-strict validation.
+)
 
 // Map from well known regex to regex pattern.
 var regex_map = map[string]*string{
@@ -468,7 +470,7 @@ func (m *Module) checkLen(len, min, max *uint64) {
 func (m *Module) checkWellKnownRegex(wk validate.KnownRegex, r *validate.StringRules) {
 	if wk != 0 {
 		m.Assert(r.Pattern == nil, "regex `well_known_regex` and regex `pattern` are incompatible")
-		var non_strict = r.Strict != nil && *r.Strict == false
+		non_strict := r.Strict != nil && *r.Strict == false
 		if (wk.String() == "HTTP_HEADER_NAME" || wk.String() == "HTTP_HEADER_VALUE") && non_strict {
 			// Use non-strict header validation.
 			r.Pattern = regex_map["HEADER_STRING"]

--- a/module/validate.go
+++ b/module/validate.go
@@ -1,12 +1,13 @@
 package module
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/envoyproxy/protoc-gen-validate/templates"
 	"github.com/envoyproxy/protoc-gen-validate/templates/java"
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
-	"path/filepath"
-	"strings"
 )
 
 const (

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -167,7 +167,8 @@ func (fns CCFuncs) packageName(msg pgs.Entity) string {
 
 func (fns CCFuncs) quote(s interface {
 	String() string
-}) string {
+},
+) string {
 	return strconv.Quote(s.String())
 }
 
@@ -262,7 +263,8 @@ func (fns CCFuncs) lit(x interface{}) string {
 
 func (fns CCFuncs) isBytes(f interface {
 	ProtoType() pgs.ProtoType
-}) bool {
+},
+) bool {
 	return f.ProtoType() == pgs.BytesT
 }
 

--- a/templates/go/register.go
+++ b/templates/go/register.go
@@ -3,8 +3,8 @@ package golang
 import (
 	"text/template"
 
-	"github.com/lyft/protoc-gen-star"
 	"github.com/envoyproxy/protoc-gen-validate/templates/goshared"
+	pgs "github.com/lyft/protoc-gen-star"
 )
 
 func Register(tpl *template.Template, params pgs.Parameters) {

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -194,7 +194,8 @@ func (fns goSharedFuncs) lit(x interface{}) string {
 
 func (fns goSharedFuncs) isBytes(f interface {
 	ProtoType() pgs.ProtoType
-}) bool {
+},
+) bool {
 	return f.ProtoType() == pgs.BytesT
 }
 

--- a/templates/java/register.go
+++ b/templates/java/register.go
@@ -377,7 +377,6 @@ func (fns javaFuncs) javaTypeFor(ctx shared.RuleContext) string {
 }
 
 func (fns javaFuncs) javaTypeForProtoType(t pgs.ProtoType) string {
-
 	switch t {
 	case pgs.Int32T, pgs.UInt32T, pgs.SInt32, pgs.Fixed32T, pgs.SFixed32:
 		return "Integer"

--- a/templates/pkg.go
+++ b/templates/pkg.go
@@ -3,17 +3,19 @@ package templates
 import (
 	"text/template"
 
-	"github.com/lyft/protoc-gen-star"
-	"github.com/lyft/protoc-gen-star/lang/go"
 	"github.com/envoyproxy/protoc-gen-validate/templates/cc"
 	"github.com/envoyproxy/protoc-gen-validate/templates/ccnop"
-	"github.com/envoyproxy/protoc-gen-validate/templates/go"
+	golang "github.com/envoyproxy/protoc-gen-validate/templates/go"
 	"github.com/envoyproxy/protoc-gen-validate/templates/java"
 	"github.com/envoyproxy/protoc-gen-validate/templates/shared"
+	pgs "github.com/lyft/protoc-gen-star"
+	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
 )
 
-type RegisterFn func(tpl *template.Template, params pgs.Parameters)
-type FilePathFn func(f pgs.File, ctx pgsgo.Context, tpl *template.Template) *pgs.FilePath
+type (
+	RegisterFn func(tpl *template.Template, params pgs.Parameters)
+	FilePathFn func(f pgs.File, ctx pgsgo.Context, tpl *template.Template) *pgs.FilePath
+)
 
 func makeTemplate(ext string, fn RegisterFn, params pgs.Parameters) *template.Template {
 	tpl := template.New(ext)

--- a/templates/shared/disabled.go
+++ b/templates/shared/disabled.go
@@ -2,7 +2,7 @@ package shared
 
 import (
 	"github.com/envoyproxy/protoc-gen-validate/validate"
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
 )
 
 // Disabled returns true if validations are disabled for msg
@@ -11,7 +11,7 @@ func Disabled(msg pgs.Message) (disabled bool, err error) {
 	return
 }
 
-// Ignore returns true if validations aren't to be generated for msg
+// Ignored returns true if validations aren't to be generated for msg
 func Ignored(msg pgs.Message) (ignored bool, err error) {
 	_, err = msg.Extension(validate.E_Ignored, &ignored)
 	return

--- a/templates/shared/functions.go
+++ b/templates/shared/functions.go
@@ -3,10 +3,10 @@ package shared
 import (
 	"text/template"
 
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
 )
 
-func RegisterFunctions(tpl *template.Template, params pgs.Parameters) {
+func RegisterFunctions(tpl *template.Template, _ pgs.Parameters) {
 	tpl.Funcs(map[string]interface{}{
 		"disabled":  Disabled,
 		"ignored":   Ignored,

--- a/templates/shared/well_known.go
+++ b/templates/shared/well_known.go
@@ -2,7 +2,7 @@ package shared
 
 import (
 	"github.com/envoyproxy/protoc-gen-validate/validate"
-	"github.com/lyft/protoc-gen-star"
+	pgs "github.com/lyft/protoc-gen-star"
 )
 
 type WellKnown string
@@ -27,7 +27,6 @@ func FileNeeds(f pgs.File, wk WellKnown) bool {
 // Needs returns true if a well-known string validator is needed for this
 // message.
 func Needs(m pgs.Message, wk WellKnown) bool {
-
 	for _, f := range m.Fields() {
 		var rules validate.FieldRules
 		if _, err := f.Extension(validate.E_Rules, &rules); err != nil {

--- a/tests/harness/go/main/harness.go
+++ b/tests/harness/go/main/harness.go
@@ -6,11 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
 	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/go"
 	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/other_package/go"
 	_ "github.com/envoyproxy/protoc-gen-validate/tests/harness/cases/yet_another_package/go"
-	"github.com/envoyproxy/protoc-gen-validate/tests/harness/go"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -54,8 +52,10 @@ func main() {
 	checkValid(err, multierr)
 }
 
-type hasAllErrors interface{ AllErrors() []error }
-type hasCause interface{ Cause() error }
+type (
+	hasAllErrors interface{ AllErrors() []error }
+	hasCause     interface{ Cause() error }
+)
 
 func checkValid(err, multierr error) {
 	if err == nil && multierr == nil {

--- a/validate/validate.pb.go
+++ b/validate/validate.pb.go
@@ -7,13 +7,14 @@
 package validate
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
Very basic housekeeping with the aid of `gofumpt` and `goimports`

Signed-off-by: Elliot Jackson <13633636+ElliotMJackson@users.noreply.github.com>