### PR TITLE
https://github.com/bufbuild/protoc-gen-validate/issues/672

### DIFF
--- a/templates/goshared/enum.go
+++ b/templates/goshared/enum.go
@@ -6,7 +6,8 @@ const enumTpl = `
 		{{ template "in" . }}
 
 		{{ if $r.GetDefinedOnly }}
-			if _, ok := {{ (typ $f).Element.Value }}_name[int32({{ accessor . }})]; !ok {
+			{{ $enumType := inType $f nil }}
+			if _, ok := {{ $enumType }}_name[int32({{ accessor . }})]; !ok {
 				err := {{ err . "value must be one of the defined enum values" }}
 				if !all { return err }
 				errors = append(errors, err)

--- a/templates/goshared/msg.go
+++ b/templates/goshared/msg.go
@@ -95,7 +95,7 @@ type {{ multierrname . }} []error
 
 // Error returns a concatenation of all the error messages it wraps.
 func (m {{ multierrname . }}) Error() string {
-	msgs := make([]string, 0, len(m))
+	var msgs []string
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
 	}

--- a/templates/goshared/register.go
+++ b/templates/goshared/register.go
@@ -338,7 +338,7 @@ func (fns goSharedFuncs) externalEnums(file pgs.File) []pgs.Enum {
 				en = fld.Type().Element().Enum()
 			}
 
-			if en != nil && en.File().Package().ProtoName() != msg.File().Package().ProtoName() {
+			if en != nil && en.Package().ProtoName() != fld.Package().ProtoName() {
 				out = append(out, en)
 			}
 		}


### PR DESCRIPTION
当一个文件引用了多个package的定义,并且都加入校验 [(validate.rules).enum.defined_only = true] ,如果这几个包的后缀都相同,例如/v1 , 生成的go代码 package alias 有问题

另外一个改动是为了避免太多diff, 回退了一个没啥影响的代码改动