### PR TITLE
Fix UTF8FirstLetterNumBytes to handle malformed UTF-8 correctly

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -156,10 +156,20 @@ inline int OneCharLen(const char* src) {
   return "\1\1\1\1\1\1\1\1\1\1\1\1\2\2\3\4"[(*src & 0xFF) >> 4];
 }
 
-inline int UTF8FirstLetterNumBytes(const char *utf8_str, int str_len) {
+inline int UTF8FirstLetterNumBytes(const char *utf8_str, ptrdiff_t str_len) {
   if (str_len == 0)
     return 0;
-  return OneCharLen(utf8_str);
+  int char_len = OneCharLen(utf8_str);
+  // Clamp to remaining bytes: a truncated multi-byte sequence
+  // counts as a single (invalid) character.
+  if (char_len > str_len)
+    return 1;
+  // Validate continuation bytes (must have 10xxxxxx pattern).
+  for (int i = 1; i < char_len; i++) {
+    if ((static_cast<unsigned char>(utf8_str[i]) & 0xC0) != 0x80)
+      return 1;  // Invalid continuation: count leader as single char.
+  }
+  return char_len;
 }
 
 inline size_t Utf8Len(const string& narrow_string) {


### PR DESCRIPTION
`UTF8FirstLetterNumBytes` in `validate/validate.h` returns the byte count from `OneCharLen` without validating that the expected continuation bytes actually follow the leader byte. Malformed UTF-8 causes `Utf8Len` to undercount characters by 2-4x, bypassing string length validation constraints (`min_len`, `max_len`, `len`).

**Example:** 20 bytes of `\xC0` (bare 2-byte leaders, no continuations) produces `Utf8Len=10` instead of 20. A field with `max_len = 10` incorrectly accepts this input.

This is exploitable when C++ protobuf deserialization doesn't enforce UTF-8 validity (the default), allowing malformed strings to reach pgv validation.

**Fix:**
- Clamp consumed bytes to remaining buffer length (prevents reading past end)
- Validate continuation bytes have the `10xxxxxx` pattern
- Return 1 for any invalid byte sequence (count as single character)

Valid UTF-8 counting is unchanged: "hello"=5, "café"=4, "你好"=2, "😀😀"=2.