### PR TITLE
Java compilation error occurs for envoy since ` v1.37.0`

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -35,9 +35,9 @@ def pgv_dependencies(maven_repos = _DEFAULT_REPOSITORIES):
         http_archive(
             name = "zlib",
             build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-            sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
-            strip_prefix = "zlib-1.2.13",
-            urls = ["https://zlib.net/fossils/zlib-1.2.13.tar.gz"],
+            sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
+            strip_prefix = "zlib-1.3.1",
+            urls = ["https://zlib.net/fossils/zlib-1.3.1.tar.gz"],
         )
 
     if not native.existing_rule("bazel_skylib"):

--- a/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
+++ b/java/pgv-java-stub/src/test/java/io/envoyproxy/pgv/StringValidationTest.java
@@ -7,6 +7,8 @@ import static io.envoyproxy.pgv.Assertions.assertValidationException;
 import static io.envoyproxy.pgv.StringValidation.uuid;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.envoyproxy.pgv.validate.PatternMessage;
+
 public class StringValidationTest {
     private static String repeat(final char c, final int n) {
         return new String(new char[n]).replace('\0', c);
@@ -106,6 +108,15 @@ public class StringValidationTest {
         Pattern p = Pattern.compile("\\* \\\\ \\w");
         // Match
         StringValidation.pattern("x", "* \\ x", p);
+    }
+
+    @Test
+    public void patternWorks3() throws ValidationException {
+        ReflectiveValidatorIndex index = new ReflectiveValidatorIndex();
+        index.validatorFor(PatternMessage.class)
+             .assertValid(PatternMessage.newBuilder().setMessage1("validtoken").build());
+        index.validatorFor(PatternMessage.class)
+             .assertValid(PatternMessage.newBuilder().setMessage2("/validpath").build());
     }
 
     @Test

--- a/java/pgv-java-stub/src/test/proto/pattern.proto
+++ b/java/pgv-java-stub/src/test/proto/pattern.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package io.envoyproxy.pgv.grpc;
+
+option java_multiple_files = true;
+option java_package = "io.envoyproxy.pgv.validate";
+import "validate/validate.proto";
+
+message PatternMessage {
+    // https://github.com/envoyproxy/envoy/blob/0baaeb4a832cd5683b221cea98b05ed139b3e332/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto#L148-L149
+    string message1 = 1 [(validate.rules).string = {pattern: "^$|^[^\\x00-\\x1f\\x7f \",;<>\\\\]+$"}];
+    // https://github.com/envoyproxy/envoy/blob/0baaeb4a832cd5683b221cea98b05ed139b3e332/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto#L49
+    string message2 = 2 [(validate.rules).string = {pattern: "^$|^/[^\\x00-\\x1f\\x7f \",;<>\\\\]*$"}];
+}

--- a/templates/java/register.go
+++ b/templates/java/register.go
@@ -442,10 +442,8 @@ func (fns javaFuncs) javaTypeLiteralSuffixForPrototype(t pgs.ProtoType) string {
 func (fns javaFuncs) javaStringEscape(s string) string {
 	s = fmt.Sprintf("%q", s)
 	s = s[1 : len(s)-1]
-	s = strings.ReplaceAll(s, `\u00`, `\x`)
-	s = strings.ReplaceAll(s, `\x`, `\\x`)
+	s = strings.NewReplacer(`\\x`, `\\x`, `\x`, `\\x`).Replace(s)
 	// s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
 	return `"` + s + `"`
 }
 


### PR DESCRIPTION
Motivation

Upstream envoy protos recently added new regex rules: e.g. `^$|^[^\\x00-\\x1f\\x7f \",;<>\\\\]+$`

This is causing a compilation error on our side:
```
/Users/user/Projects/armeria/xds-api/build/generated/sources/proto/main/javapgv/io/envoyproxy/envoy/extensions/filters/http/oauth2/v3/CookieConfigValidator.java:20: error: illegal start of expression
                com.google.re2j.Pattern PATH__PATTERN = com.google.re2j.Pattern.compile("^$|^/[^\\x00-\\x1f\\x7f \\",;<>\\\\]*$");
```

From my reading, it seems like the string escape method is causing this
https://github.com/bufbuild/protoc-gen-validate/blob/92b9a7df69ca9f71bfc492f7a90adf4d36eab569/templates/java/register.go#L442-L450

- `\\x` case: `%q` produces `\\x00`, `ReplaceAll` matches `\x` within it and over-escapes to `\\\x00`
- `"` case: `%q` already produces `\"`, the extra `ReplaceAll` over-escapes to `\\"`

This currently requires the following workaround https://github.com/line/armeria/pull/6714

Modifications

- Removed `\u00` rewrites since Java natively supports them anyways
- Removed `ReplaceAll(s, `"`, `\"`)` since this is handled by `Sprintf`
- Rewrite `\x` to `\\x` only if exactly `\x` (without a prepending backslash)

Misc
- Updated zlib from 1.2.13 to 1.3.1 in `bazel/repositories.bzl` to fix local build errors on macOS. Happy to revert if maintainers prefer.
