### PR TITLE
[Security Vulnerability] protoc-gen-validate Java Code Injection

### DIFF
--- a/templates/java/register.go
+++ b/templates/java/register.go
@@ -439,14 +439,45 @@ func (fns javaFuncs) javaTypeLiteralSuffixForPrototype(t pgs.ProtoType) string {
 	}
 }
 
+// javaStringEscape returns a Java source string literal (including surrounding
+// double quotes) for s. It must not be wrapped in extra quotes in templates.
 func (fns javaFuncs) javaStringEscape(s string) string {
-	s = fmt.Sprintf("%q", s)
-	s = s[1 : len(s)-1]
-	s = strings.ReplaceAll(s, `\u00`, `\x`)
-	s = strings.ReplaceAll(s, `\x`, `\\x`)
-	// s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	return `"` + s + `"`
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else if r <= 0x7e {
+				b.WriteRune(r)
+			} else if r <= 0xffff {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				r -= 0x10000
+				high := 0xd800 + (r >> 10)
+				low := 0xdc00 + (r & 0x3ff)
+				fmt.Fprintf(&b, `\u%04x\u%04x`, high, low)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 func (fns javaFuncs) camelCase(name pgs.Name) string {

--- a/templates/java/string.go
+++ b/templates/java/string.go
@@ -4,14 +4,14 @@ const stringConstTpl = `{{ $f := .Field }}{{ $r := .Rules -}}
 {{- if $r.In }}
 		private final {{ javaTypeFor . }}[] {{ constantName . "In" }} = new {{ javaTypeFor . }}[]{
 			{{- range $r.In -}}
-				"{{- sprintf "%v" . -}}",
+				{{ javaStringEscape (sprintf "%v" .) }},
 			{{- end -}}
 		};
 {{- end -}}
 {{- if $r.NotIn }}
 		private final {{ javaTypeFor . }}[] {{ constantName . "NotIn" }} = new {{ javaTypeFor . }}[]{
 			{{- range $r.NotIn -}}
-				"{{- sprintf "%v" . -}}",
+				{{ javaStringEscape (sprintf "%v" .) }},
 			{{- end -}}
 		};
 {{- end -}}
@@ -24,7 +24,7 @@ const stringTpl = `{{ $f := .Field }}{{ $r := .Rules -}}
 			if ( !{{ accessor . }}.isEmpty() ) {
 {{- end -}}
 {{- if $r.Const }}
-			io.envoyproxy.pgv.ConstantValidation.constant("{{ $f.FullyQualifiedName }}", {{ accessor . }}, "{{ $r.GetConst }}");
+			io.envoyproxy.pgv.ConstantValidation.constant("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ javaStringEscape $r.GetConst }});
 {{- end -}}
 {{- if $r.In }}
 			io.envoyproxy.pgv.CollectiveValidation.in("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ constantName . "In" }});
@@ -54,16 +54,16 @@ const stringTpl = `{{ $f := .Field }}{{ $r := .Rules -}}
 			io.envoyproxy.pgv.StringValidation.pattern("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ constantName . "Pattern" }});
 {{- end -}}
 {{- if $r.Prefix }}
-			io.envoyproxy.pgv.StringValidation.prefix("{{ $f.FullyQualifiedName }}", {{ accessor . }}, "{{ $r.GetPrefix }}");
+			io.envoyproxy.pgv.StringValidation.prefix("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ javaStringEscape $r.GetPrefix }});
 {{- end -}}
 {{- if $r.Contains }}
-			io.envoyproxy.pgv.StringValidation.contains("{{ $f.FullyQualifiedName }}", {{ accessor . }}, "{{ $r.GetContains }}");
+			io.envoyproxy.pgv.StringValidation.contains("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ javaStringEscape $r.GetContains }});
 {{- end -}}
 {{- if $r.NotContains }}
-			io.envoyproxy.pgv.StringValidation.notContains("{{ $f.FullyQualifiedName }}", {{ accessor . }}, "{{ $r.GetNotContains }}");
+			io.envoyproxy.pgv.StringValidation.notContains("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ javaStringEscape $r.GetNotContains }});
 {{- end -}}
 {{- if $r.Suffix }}
-			io.envoyproxy.pgv.StringValidation.suffix("{{ $f.FullyQualifiedName }}", {{ accessor . }}, "{{ $r.GetSuffix }}");
+			io.envoyproxy.pgv.StringValidation.suffix("{{ $f.FullyQualifiedName }}", {{ accessor . }}, {{ javaStringEscape $r.GetSuffix }});
 {{- end -}}
 {{- if $r.GetEmail }}
 			io.envoyproxy.pgv.StringValidation.email("{{ $f.FullyQualifiedName }}", {{ accessor . }});


### PR DESCRIPTION
## Summary

Unescaped proto string values (GetConst, GetPrefix, GetContains, GetNotContains, GetSuffix) are interpolated into Java string literals in generated validator code. A malicious .proto file with crafted validation rules causes arbitrary Java code execution when the generated code is compiled and run.

## Description

- **Type**: Code injection in generated Java code
- **Source**: Proto validation rules (string.const, string.prefix, string.suffix, string.contains, string.not_contains) from user-controlled .proto files
- **Sink**: Java string literals in `templates/java/string.go` (lines 27, 57, 60, 63, 66) — values embedded as `{{ $r.GetConst }}` etc. without javaStringEscape
- **Impact**: Arbitrary Java execution. Example payload `"); System.exit(0); //` breaks out of the string literal and executes injected code when the validator's assertValid() is invoked. Because `java.lang.Runtime` requires no import, injected statements can also run host commands—for example: `Process p = Runtime.getRuntime().exec(new String[] { "/bin/sh", "-c", "echo hello" }); p.waitFor();`—which is full RCE at the JVM/OS level, not limited to `System.exit`.

## Affected

- bufbuild/protoc-gen-validate (Java code generation path)
- Affected file: `templates/java/string.go`

## PoC
For POC, Check the Gist: https://gist.github.com/hayageek/6b2d3518bcf8d35f15940137862cef44