### PR TITLE
C++ include netinet/in.h and sys/socket.h on non-Windows

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -11,6 +11,8 @@
 
 #if !defined(_WIN32)
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #else
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
arpa/inet.h does not guarantee that socket types (struct sockaddr, socklen_t, etc.) are defined on all POSIX platforms.  FreeBSD in particular requires netinet/in.h and sys/socket.h to be included explicitly.  Add both under the existing !_WIN32 guard.