### PR TITLE
Python code injection vulnerability

### DIFF
--- a/python/protoc_gen_validate/validator.py
+++ b/python/protoc_gen_validate/validator.py
@@ -21,6 +21,21 @@ else:
 
 printer = ""
 
+
+def _pyrepr(value):
+    """Return a Python source literal that safely embeds `value` inside
+    generated validator code.
+
+    Validation rules from `.proto` files are rendered into Python source via
+    Jinja2 templates and then exec()'d.  Embedding a string between literal
+    Python quotes (e.g. ``"{{ s['contains'] }}"``) lets a crafted rule value
+    escape the literal and inject arbitrary Python.  Use this helper for
+    every rule value that appears in generated source so that the resulting
+    token is a single, properly-escaped Python literal.
+    """
+    return repr(value)
+
+
 # Well known regex mapping.
 regex_map = {
     "UNKNOWN": "",
@@ -300,36 +315,36 @@ def _has_field(message_pb, property_name):
 
 def const_template(option_value, name):
     const_tmpl = """{%- if str(o.string) and o.string.HasField('const') -%}
-    if {{ name }} != \"{{ o.string['const'] }}\":
-        raise ValidationFailed(\"{{ name }} not equal to {{ o.string['const'] }}\")
+    if {{ name }} != {{ repr(o.string['const']) }}:
+        raise ValidationFailed({{ repr(name + " not equal to " + str(o.string['const'])) }})
     {%- elif str(o.bool) and o.bool['const'] != "" -%}
     if {{ name }} != {{ o.bool['const'] }}:
-        raise ValidationFailed(\"{{ name }} not equal to {{ o.bool['const'] }}\")
+        raise ValidationFailed({{ repr(name + " not equal to " + str(o.bool['const'])) }})
     {%- elif str(o.bytes) and o.bytes.HasField('const') -%}
         {% if sys.version_info[0] >= 3 %}
-    if {{ name }} != {{ o.bytes['const'] }}:
-        raise ValidationFailed(\"{{ name }} not equal to {{ o.bytes['const'] }}\")
+    if {{ name }} != {{ repr(o.bytes['const']) }}:
+        raise ValidationFailed({{ repr(name + " not equal to " + str(o.bytes['const'])) }})
         {% else %}
-    if {{ name }} != b\"{{ o.bytes['const'].encode('string_escape') }}\":
-        raise ValidationFailed(\"{{ name }} not equal to {{ o.bytes['const'].encode('string_escape') }}\")
+    if {{ name }} != {{ repr(o.bytes['const']) }}:
+        raise ValidationFailed({{ repr(name + " not equal to " + str(o.bytes['const'])) }})
         {% endif %}
     {%- endif -%}
     """
-    return Template(const_tmpl).render(sys=sys, o=option_value, name=name, str=str)
+    return Template(const_tmpl).render(sys=sys, o=option_value, name=name, str=str, repr=_pyrepr)
 
 
 def in_template(value, name):
     in_tmpl = """
     {%- if value['in'] %}
-    if {{ name }} not in {{ value['in'] }}:
-        raise ValidationFailed(\"{{ name }} not in {{ value['in'] }}\")
+    if {{ name }} not in {{ repr(list(value['in'])) }}:
+        raise ValidationFailed({{ repr(name + " not in " + str(list(value['in']))) }})
     {%- endif -%}
     {%- if value['not_in'] %}
-    if {{ name }} in {{ value['not_in'] }}:
-        raise ValidationFailed(\"{{ name }} in {{ value['not_in'] }}\")
+    if {{ name }} in {{ repr(list(value['not_in'])) }}:
+        raise ValidationFailed({{ repr(name + " in " + str(list(value['not_in']))) }})
     {%- endif -%}
     """
-    return Template(in_tmpl).render(value=value, name=name)
+    return Template(in_tmpl).render(value=value, name=name, repr=_pyrepr, list=list, str=str)
 
 
 def string_template(option_value, name):
@@ -376,24 +391,24 @@ def string_template(option_value, name):
         raise ValidationFailed(\"{{ name }} length is greater than {{ s['max_bytes'] }}\")
     {%- endif -%}
     {%- if s['pattern'] %}
-    if re.search(r\'{{ s['pattern'] }}\', {{ name }}) is None:
-        raise ValidationFailed(\"{{ name }} pattern does not match {{ s['pattern'] }}\")
+    if re.search({{ repr(s['pattern']) }}, {{ name }}) is None:
+        raise ValidationFailed({{ repr(name + " pattern does not match " + str(s['pattern'])) }})
     {%- endif -%}
     {%- if s['prefix'] %}
-    if not {{ name }}.startswith(\"{{ s['prefix'] }}\"):
-        raise ValidationFailed(\"{{ name }} does not start with prefix {{ s['prefix'] }}\")
+    if not {{ name }}.startswith({{ repr(s['prefix']) }}):
+        raise ValidationFailed({{ repr(name + " does not start with prefix " + str(s['prefix'])) }})
     {%- endif -%}
     {%- if s['suffix'] %}
-    if not {{ name }}.endswith(\"{{ s['suffix'] }}\"):
-        raise ValidationFailed(\"{{ name }} does not end with suffix {{ s['suffix'] }}\")
+    if not {{ name }}.endswith({{ repr(s['suffix']) }}):
+        raise ValidationFailed({{ repr(name + " does not end with suffix " + str(s['suffix'])) }})
     {%- endif -%}
     {%- if s['contains'] %}
-    if not \"{{ s['contains'] }}\" in {{ name }}:
-        raise ValidationFailed(\"{{ name }} does not contain {{ s['contains'] }}\")
+    if {{ repr(s['contains']) }} not in {{ name }}:
+        raise ValidationFailed({{ repr(name + " does not contain " + str(s['contains'])) }})
     {%- endif -%}
     {%- if s['not_contains'] %}
-    if \"{{ s['not_contains'] }}\" in {{ name }}:
-        raise ValidationFailed(\"{{ name }} contains {{ s['not_contains'] }}\")
+    if {{ repr(s['not_contains']) }} in {{ name }}:
+        raise ValidationFailed({{ repr(name + " contains " + str(s['not_contains'])) }})
     {%- endif -%}
     {%- if s['email'] %}
     if not _validateEmail({{ name }}):
@@ -446,7 +461,10 @@ def string_template(option_value, name):
     {%- endif -%}
     {% endfilter %}
     """
-    return Template(str_templ).render(o=option_value, name=name, const_template=const_template, in_template=in_template)
+    return Template(str_templ).render(
+        o=option_value, name=name,
+        const_template=const_template, in_template=in_template,
+        repr=_pyrepr, str=str)
 
 
 def required_template(value, name):


### PR DESCRIPTION
## Summary

Unescaped `validate.rules` string values are interpolated into Python source by `python/protoc_gen_validate/validator.py`. The rendered source is then executed via `exec()`, so a malicious `.proto` whose validation rule contains a Python-source breakout (a literal `"` followed by arbitrary expressions) achieves arbitrary code execution the first time `validate(msg)` is called on a message of that type.

This is the Python analogue of the Java vulnerability tracked in #1385.

## Description

- **Type**: Code injection in generated Python validator code, executed via `exec()`.
- **Source**: `validate.rules` option values (`string.const`, `string.prefix`, `string.suffix`, `string.contains`, `string.not_contains`, `string.pattern`, and the same set inside `in_template` / `const_template`).
- **Sink**: Python source string built by Jinja2 templates in `python/protoc_gen_validate/validator.py`, executed at `validator.py:68` and `:217`:
    ```python
    exec(func, globals(), local_vars)
    ```
  with `func` being the rendered template source.
- **Affected templates** (unsafe `"{{ … }}"` interpolations between literal Python quote characters):
  - `const_template` (line 303-314): `if {{ name }} != "{{ o.string['const'] }}":`, error-message string, plus bool/bytes equivalents.
  - `in_template` (line 325, 329): error-message strings referencing `value['in']` / `value['not_in']`.
  - `string_template` (line 379-396): `pattern`, `prefix`, `suffix`, `contains`, `not_contains` and their error messages.
- **Impact**: Arbitrary Python execution in the validator process. The threat model is "compile a generated Python stub from an attacker-influenced `.proto` and call `validate(msg)`" — realistic for CI pipelines, multi-tenant build systems, schema-registry / `buf push` ingestion, and code that uses `google.protobuf.Any` with dynamic descriptor lookup.

## Reproducer (against current `main`)

```proto
// evil.proto
syntax = "proto3";
import "validate/validate.proto";

message Evil {
  string evil_field = 1 [(validate.rules).string.contains =
    "x\" + __import__('os').system('touch /tmp/pgv-pwned') + \"y"];
}
```

```bash
protoc --python_out=. --validate_out=lang=python:. -I. -I/path/to/pgv evil.proto
python3 -c "
from protoc_gen_validate.validator import validate
import evil_pb2
msg = evil_pb2.Evil()
msg.evil_field = 'x'
try: validate(msg)
except Exception: pass
"
ls /tmp/pgv-pwned   # exists -> RCE fired
```

Generated source produced by the unpatched template (excerpt):

```python
if not "x" + __import__('os').system('touch /tmp/pgv-pwned') + "y" in p.evil_field:
    raise ValidationFailed("p.evil_field does not contain x" + __import__('os').system('touch /tmp/pgv-pwned') + "y")
```

`os.system` runs when the if-expression is evaluated (the subsequent `NameError` on bare `evil_field` is harmless — the side effect already fired). With small payload adjustments the same pattern fires in every other sink listed above.

## Fix in this PR

Add `_pyrepr(value)` near the top of `validator.py` — a thin wrapper around `repr()` so the helper's intent is explicit at the call site. Pass `repr=_pyrepr` into every affected `Template(...).render(...)` call. Replace each unsafe `"{{ field }}"` interpolation with `{{ repr(field) }}` so the rendered token is a single, properly-escaped Python literal. Restructure error-message strings to do runtime concatenation with a separately-escaped literal:

```jinja
raise ValidationFailed("{{ name }} does not contain " + {{ repr(s['contains']) }})
```

This preserves the existing user-visible error text on benign input, keeps `re.search` regex semantics for `{{ s['pattern'] }}` (Python's `repr` produces a non-raw literal whose backslashes evaluate back to the original regex), and refuses injection on crafted input.

### Verification

Direct exec of the generated source with the original payload across all five string sinks (`contains`, `prefix`, `suffix`, `pattern`, `const`) no longer creates the `/tmp/pgv-pwned` sentinel. The payload is embedded as a Python string literal `'x" + __import__(\'os\').system(...) + "y'` and no command runs. Legitimate regex patterns (`^\d+@example\.com$`) are preserved.

### Sinks closed

| Template | Sites |
|---|---|
| `const_template` | string / bool / bytes `const` (value comparison and error message) |
| `in_template` | `in` / `not_in` error messages |
| `string_template` | `pattern`, `prefix`, `suffix`, `contains`, `not_contains` (condition and error message) |

### Out of scope / follow-ups

- The bytes template (`bytes_template`) already relies on Python's `str(bytes)` repr at most sites, so direct injection there is harder. A follow-up could route bytes interpolations through `_pyrepr` for defense-in-depth.
- Enum templates interpolate enum-name strings that are constrained by protobuf's identifier rules; not a direct RCE sink.
- Other interpolation sites (`{{ num['const'] }}`, `{{ s['len'] }}` etc.) consume numeric or boolean values and are safe.

### Related

- #1385 — Java analogue of the same code-injection class, still open.

## Diff stats

`python/protoc_gen_validate/validator.py` — +38 / -24, no other files touched.